### PR TITLE
Add IdpList field on AppConfiguraiton

### DIFF
--- a/pkg/services/apps/model.go
+++ b/pkg/services/apps/model.go
@@ -66,6 +66,7 @@ type AppConfiguration struct {
 	TokenEndpointAuthMethod       *int32  `json:"token_endpoint_auth_method,omitempty"`
 	AccessTokenExpirationMinutes  *int32  `json:"access_token_expiration_minutes,omitempty"`
 	ProviderArn                   *string `json:"provider_arn,omitempty"`
+	IdpList                       *string `json:"idp_list,omitempty"`
 	SignatureAlgorithm            *string `json:"signature_algorithm,omitempty"`
 
 	LogoutURL                    *string `json:"logout_url,omitempty"`


### PR DESCRIPTION
* AWS Multi Account  app require saml identifier provider, see attached 
<img src="https://user-images.githubusercontent.com/9511819/109422448-e08ee200-7a1e-11eb-8e29-6b971931d9d0.png" width="400px">

* This PR add field to support managing saml idp configuration. The field name is confirmed via api
```
curl 'https://api.us.onelogin.com/api/2/apps/<appid>' -X GET -H "Authorization: bearer $TOKEN" | jq '.configuration.idp_list'
```