### PR TITLE
Multiple Critical Fixes

### DIFF
--- a/internal/test/test_repository.go
+++ b/internal/test/test_repository.go
@@ -5,8 +5,8 @@ import (
 )
 
 type MockRepository struct {
-	ReadFunc      func(r interface{}) ([]byte, error)
-	ReReadFunc    []func(r interface{}) ([]byte, error)
+	ReadFunc      func(r interface{}) ([][]byte, error)
+	ReReadFunc    []func(r interface{}) ([][]byte, error)
 	CreateFunc    func(r interface{}) ([]byte, error)
 	SubCreateFunc []func(r interface{}) ([]byte, error)
 	UpdateFunc    func(r interface{}) ([]byte, error)
@@ -20,7 +20,7 @@ type MockRepository struct {
 // response based on request parameters such as the request URL. A ReReadFunc is allowed
 // because RESTful reads are idempotent, however, you may want to mock a subsequent read,
 // following an error recovery scenario where some updates were saved, but others were abandoned.
-func (mr *MockRepository) Read(r interface{}) ([]byte, error) {
+func (mr *MockRepository) Read(r interface{}) ([][]byte, error) {
 	if mr.ReReads > 0 && len(mr.ReReadFunc) > 0 {
 		mr.ReReads++
 		return mr.ReReadFunc[mr.ReReads-2](r)

--- a/pkg/services/apps/app_rules/app_rules_test.go
+++ b/pkg/services/apps/app_rules/app_rules_test.go
@@ -38,13 +38,14 @@ func TestQuery(t *testing.T) {
 				Actions:    []AppRuleActions{{Action: oltypes.String("test"), Value: []string{"test"}, Expression: oltypes.String(".*")}}},
 			},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]AppRule{AppRule{
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]AppRule{AppRule{
 						ID:         oltypes.Int32(1),
 						Name:       oltypes.String("name"),
 						Conditions: []AppRuleConditions{{Source: oltypes.String("test"), Operator: oltypes.String(">"), Value: oltypes.String("90")}},
 						Actions:    []AppRuleActions{{Action: oltypes.String("test"), Value: []string{"test"}, Expression: oltypes.String(".*")}}},
 					})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -53,7 +54,7 @@ func TestQuery(t *testing.T) {
 			mockLegalValues: &MockLegalValuesService{},
 			expectedError:   errors.New("error"),
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
+				ReadFunc: func(r interface{}) ([][]byte, error) {
 					return nil, errors.New("error")
 				},
 			},
@@ -63,8 +64,9 @@ func TestQuery(t *testing.T) {
 			mockLegalValues:  &MockLegalValuesService{},
 			expectedResponse: []AppRule{AppRule{}},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]AppRule{AppRule{}})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]AppRule{AppRule{}})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -100,13 +102,14 @@ func TestGetOne(t *testing.T) {
 				Actions:    []AppRuleActions{{Action: oltypes.String("test"), Value: []string{"test"}, Expression: oltypes.String(".*")}},
 			},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(AppRule{
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(AppRule{
 						ID:         oltypes.Int32(1),
 						Name:       oltypes.String("name"),
 						Conditions: []AppRuleConditions{{Source: oltypes.String("test"), Operator: oltypes.String(">"), Value: oltypes.String("90")}},
 						Actions:    []AppRuleActions{{Action: oltypes.String("test"), Value: []string{"test"}, Expression: oltypes.String(".*")}},
 					})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -116,7 +119,7 @@ func TestGetOne(t *testing.T) {
 			mockLegalValues: &MockLegalValuesService{},
 			expectedError:   errors.New("error"),
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
+				ReadFunc: func(r interface{}) ([][]byte, error) {
 					return nil, errors.New("error")
 				},
 			},
@@ -127,8 +130,9 @@ func TestGetOne(t *testing.T) {
 			mockLegalValues:  &MockLegalValuesService{},
 			expectedResponse: &AppRule{},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]AppRule{AppRule{}})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]AppRule{AppRule{}})
+					return [][]byte{b}, err
 				},
 			},
 		},

--- a/pkg/services/apps/app_rules/v2.go
+++ b/pkg/services/apps/app_rules/v2.go
@@ -44,7 +44,13 @@ func (svc *V2Service) Query(query *AppRuleQuery) ([]AppRule, error) {
 	}
 
 	var appRules []AppRule
-	json.Unmarshal(resp, &appRules)
+
+	for _, bytes := range resp {
+		var unmarshalled []AppRule
+		json.Unmarshal(bytes, &unmarshalled)
+		appRules = append(appRules, unmarshalled...)
+	}
+
 	return appRules, nil
 }
 
@@ -61,7 +67,10 @@ func (svc *V2Service) GetOne(appId int32, id int32) (*AppRule, error) {
 	}
 
 	var appRule AppRule
-	json.Unmarshal(resp, &appRule)
+	if len(resp) < 1 {
+		return nil, errors.New("invalid length of response returned")
+	}
+	json.Unmarshal(resp[0], &appRule)
 	return &appRule, nil
 }
 

--- a/pkg/services/apps/apps_test.go
+++ b/pkg/services/apps/apps_test.go
@@ -24,8 +24,9 @@ func TestQuery(t *testing.T) {
 				App{ID: oltypes.Int32(1), Name: oltypes.String("name")},
 			},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]App{App{ID: oltypes.Int32(1), Name: oltypes.String("name")}})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]App{App{ID: oltypes.Int32(1), Name: oltypes.String("name")}})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -36,12 +37,13 @@ func TestQuery(t *testing.T) {
 				App{ID: oltypes.Int32(1), Name: oltypes.String("name2")},
 			},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
+				ReadFunc: func(r interface{}) ([][]byte, error) {
 					availableApps := []App{
 						App{ID: oltypes.Int32(1), Name: oltypes.String("name")},
 						App{ID: oltypes.Int32(1), Name: oltypes.String("name2")},
 					}
-					return json.Marshal(availableApps)
+					b, err := json.Marshal(availableApps)
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -55,8 +57,9 @@ func TestQuery(t *testing.T) {
 			queryPayload:     &AppsQuery{Name: "???"},
 			expectedResponse: []App{},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]App{})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]App{})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -84,8 +87,9 @@ func TestGetOne(t *testing.T) {
 			id:               int32(1),
 			expectedResponse: &App{ID: oltypes.Int32(1), Name: oltypes.String("name")},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(App{ID: oltypes.Int32(1), Name: oltypes.String("name")})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(App{ID: oltypes.Int32(1), Name: oltypes.String("name")})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -128,8 +132,9 @@ func TestUpdate(t *testing.T) {
 				UpdateFunc: func(r interface{}) ([]byte, error) {
 					return json.Marshal(App{ID: oltypes.Int32(1), Name: oltypes.String("updated")})
 				},
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(App{ID: oltypes.Int32(1), Name: oltypes.String("updated")})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(App{ID: oltypes.Int32(1), Name: oltypes.String("updated")})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -154,11 +159,13 @@ func TestUpdate(t *testing.T) {
 				UpdateFunc: func(r interface{}) ([]byte, error) {
 					return json.Marshal(App{ID: oltypes.Int32(1), Name: oltypes.String("name"), Parameters: map[string]AppParameters{"test": AppParameters{ID: oltypes.Int32(1)}}})
 				},
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(App{ID: oltypes.Int32(1), Name: oltypes.String("name")})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(App{ID: oltypes.Int32(1), Name: oltypes.String("name")})
+					return [][]byte{b}, err
 				},
-				ReReadFunc: []func(r interface{}) ([]byte, error){func(r interface{}) ([]byte, error) {
-					return json.Marshal(App{ID: oltypes.Int32(1), Name: oltypes.String("name")})
+				ReReadFunc: []func(r interface{}) ([][]byte, error){func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(App{ID: oltypes.Int32(1), Name: oltypes.String("name")})
+					return [][]byte{b}, err
 				}},
 				DestroyFunc: func(r interface{}) ([]byte, error) {
 					return nil, nil
@@ -180,11 +187,13 @@ func TestUpdate(t *testing.T) {
 				UpdateFunc: func(r interface{}) ([]byte, error) {
 					return json.Marshal(App{ID: oltypes.Int32(1), Name: oltypes.String("name"), Parameters: map[string]AppParameters{"test": AppParameters{ID: oltypes.Int32(1)}}})
 				},
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(App{ID: oltypes.Int32(1), Name: oltypes.String("name"), Parameters: map[string]AppParameters{"test": AppParameters{ID: oltypes.Int32(1)}}})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(App{ID: oltypes.Int32(1), Name: oltypes.String("name"), Parameters: map[string]AppParameters{"test": AppParameters{ID: oltypes.Int32(1)}}})
+					return [][]byte{b}, err
 				},
-				ReReadFunc: []func(r interface{}) ([]byte, error){func(r interface{}) ([]byte, error) {
-					return json.Marshal(App{ID: oltypes.Int32(1), Name: oltypes.String("name"), Parameters: map[string]AppParameters{"test": AppParameters{ID: oltypes.Int32(1)}}})
+				ReReadFunc: []func(r interface{}) ([][]byte, error){func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(App{ID: oltypes.Int32(1), Name: oltypes.String("name"), Parameters: map[string]AppParameters{"test": AppParameters{ID: oltypes.Int32(1)}}})
+					return [][]byte{b}, err
 				}},
 				DestroyFunc: func(r interface{}) ([]byte, error) {
 					return nil, errors.New("error")
@@ -258,8 +267,9 @@ func TestCreate(t *testing.T) {
 					resp := App{Name: app.Name, ID: app.ID}
 					return json.Marshal(resp)
 				},
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(App{ID: oltypes.Int32(1), Name: oltypes.String("name")})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(App{ID: oltypes.Int32(1), Name: oltypes.String("name")})
+					return [][]byte{b}, err
 				},
 			},
 		},

--- a/pkg/services/apps/v2.go
+++ b/pkg/services/apps/v2.go
@@ -40,7 +40,15 @@ func (svc *V2Service) Query(query *AppsQuery) ([]App, error) {
 	}
 
 	var apps []App
-	json.Unmarshal(resp, &apps)
+	for _, bytes := range resp {
+		var unmarshalled []App
+		json.Unmarshal(bytes, &unmarshalled)
+		if len(apps) == 0 {
+			apps = unmarshalled
+		} else {
+			apps = append(apps, unmarshalled...)
+		}
+	}
 
 	return apps, nil
 }
@@ -58,7 +66,10 @@ func (svc *V2Service) GetOne(id int32) (*App, error) {
 	}
 
 	var app App
-	json.Unmarshal(resp, &app)
+	if len(resp) < 1 {
+		return nil, errors.New("invalid length of response returned")
+	}
+	json.Unmarshal(resp[0], &app)
 
 	return &app, nil
 }

--- a/pkg/services/auth_servers/access_token_claims/access_token_claims_test.go
+++ b/pkg/services/auth_servers/access_token_claims/access_token_claims_test.go
@@ -43,8 +43,8 @@ func TestQuery(t *testing.T) {
 				},
 			},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]AccessTokenClaim{
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]AccessTokenClaim{
 						AccessTokenClaim{
 							ID:                       oltypes.Int32(int32(1)),
 							Label:                    oltypes.String("label"),
@@ -68,6 +68,7 @@ func TestQuery(t *testing.T) {
 							ProvisionedEntitlements:  oltypes.Bool(true),
 						},
 					})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -75,7 +76,7 @@ func TestQuery(t *testing.T) {
 			queryPayload:  &AccessTokenClaimsQuery{AuthServerID: "1"},
 			expectedError: errors.New("error"),
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
+				ReadFunc: func(r interface{}) ([][]byte, error) {
 					return nil, errors.New("error")
 				},
 			},

--- a/pkg/services/auth_servers/access_token_claims/v2.go
+++ b/pkg/services/auth_servers/access_token_claims/v2.go
@@ -39,7 +39,11 @@ func (svc *V2Service) Query(query *AccessTokenClaimsQuery) ([]AccessTokenClaim, 
 	}
 
 	var accessTokenClaims []AccessTokenClaim
-	json.Unmarshal(resp, &accessTokenClaims)
+	for _, bytes := range resp {
+		var unmarshalled []AccessTokenClaim
+		json.Unmarshal(bytes, &unmarshalled)
+		accessTokenClaims = append(accessTokenClaims, unmarshalled...)
+	}
 	return accessTokenClaims, nil
 }
 

--- a/pkg/services/auth_servers/auth_servers_test.go
+++ b/pkg/services/auth_servers/auth_servers_test.go
@@ -29,8 +29,8 @@ func TestQuery(t *testing.T) {
 				},
 			},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]AuthServer{
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]AuthServer{
 						AuthServer{
 							ID:   oltypes.Int32(1),
 							Name: oltypes.String("name"),
@@ -40,6 +40,7 @@ func TestQuery(t *testing.T) {
 							},
 						},
 					})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -64,8 +65,8 @@ func TestQuery(t *testing.T) {
 				},
 			},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]AuthServer{
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]AuthServer{
 						AuthServer{
 							ID:   oltypes.Int32(1),
 							Name: oltypes.String("name"),
@@ -83,6 +84,7 @@ func TestQuery(t *testing.T) {
 							},
 						},
 					})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -123,8 +125,8 @@ func TestGetOne(t *testing.T) {
 				},
 			},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(AuthServer{
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(AuthServer{
 						ID:   oltypes.Int32(1),
 						Name: oltypes.String("name"),
 						Configuration: &AuthServerConfiguration{
@@ -132,6 +134,7 @@ func TestGetOne(t *testing.T) {
 							Audiences:          []string{"example.com/contacts", "example.com/people"},
 						},
 					})
+					return [][]byte{b}, err
 				},
 			},
 		},

--- a/pkg/services/auth_servers/client_apps/client_apps_test.go
+++ b/pkg/services/auth_servers/client_apps/client_apps_test.go
@@ -63,8 +63,8 @@ func TestQuery(t *testing.T) {
 				},
 			},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]ClientApp{
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]ClientApp{
 						ClientApp{
 							ID:           oltypes.Int32(int32(1)),
 							AuthServerID: oltypes.Int32(int32(1)),
@@ -106,6 +106,7 @@ func TestQuery(t *testing.T) {
 							},
 						},
 					})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -113,7 +114,7 @@ func TestQuery(t *testing.T) {
 			queryPayload:  &ClientAppsQuery{AuthServerID: "1"},
 			expectedError: errors.New("error"),
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
+				ReadFunc: func(r interface{}) ([][]byte, error) {
 					return nil, errors.New("error")
 				},
 			},

--- a/pkg/services/auth_servers/client_apps/v2.go
+++ b/pkg/services/auth_servers/client_apps/v2.go
@@ -39,7 +39,11 @@ func (svc *V2Service) Query(query *ClientAppsQuery) ([]ClientApp, error) {
 	}
 
 	var clients []ClientApp
-	json.Unmarshal(resp, &clients)
+	for _, bytes := range resp {
+		var unmarshalled []ClientApp
+		json.Unmarshal(bytes, &unmarshalled)
+		clients = append(clients, unmarshalled...)
+	}
 	return clients, nil
 }
 

--- a/pkg/services/auth_servers/scopes/scopes_test.go
+++ b/pkg/services/auth_servers/scopes/scopes_test.go
@@ -33,8 +33,8 @@ func TestQuery(t *testing.T) {
 				},
 			},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]Scope{
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]Scope{
 						Scope{
 							ID:           oltypes.Int32(int32(1)),
 							AuthServerID: oltypes.Int32(int32(1)),
@@ -48,6 +48,7 @@ func TestQuery(t *testing.T) {
 							Description:  oltypes.String("description"),
 						},
 					})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -55,7 +56,7 @@ func TestQuery(t *testing.T) {
 			queryPayload:  &ScopesQuery{AuthServerID: "1"},
 			expectedError: errors.New("error"),
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
+				ReadFunc: func(r interface{}) ([][]byte, error) {
 					return nil, errors.New("error")
 				},
 			},

--- a/pkg/services/auth_servers/scopes/v2.go
+++ b/pkg/services/auth_servers/scopes/v2.go
@@ -39,7 +39,11 @@ func (svc *V2Service) Query(query *ScopesQuery) ([]Scope, error) {
 	}
 
 	var scopes []Scope
-	json.Unmarshal(resp, &scopes)
+	for _, bytes := range resp {
+		var unmarshalled []Scope
+		json.Unmarshal(bytes, &unmarshalled)
+		scopes = append(scopes, unmarshalled...)
+	}
 	return scopes, nil
 }
 

--- a/pkg/services/auth_servers/v2.go
+++ b/pkg/services/auth_servers/v2.go
@@ -40,7 +40,12 @@ func (svc *V2Service) Query(query *AuthServerQuery) ([]AuthServer, error) {
 	}
 
 	var auth_servers []AuthServer
-	json.Unmarshal(resp, &auth_servers)
+	for _, bytes := range resp {
+		var unmarshalled []AuthServer
+		json.Unmarshal(bytes, &unmarshalled)
+		auth_servers = append(auth_servers, unmarshalled...)
+	}
+
 	return auth_servers, nil
 }
 
@@ -55,7 +60,10 @@ func (svc *V2Service) GetOne(id int32) (*AuthServer, error) {
 		return nil, err
 	}
 	var authServer AuthServer
-	json.Unmarshal(resp, &authServer)
+	if len(resp) < 1 {
+		return nil, errors.New("invalid length of response returned")
+	}
+	json.Unmarshal(resp[0], &authServer)
 	return &authServer, nil
 }
 

--- a/pkg/services/interfaces.go
+++ b/pkg/services/interfaces.go
@@ -7,7 +7,7 @@ import "net/http"
 // entities live such as apps or users
 type Repository interface {
 	Create(r interface{}) ([]byte, error)
-	Read(r interface{}) ([]byte, error)
+	Read(r interface{}) ([][]byte, error)
 	Update(r interface{}) ([]byte, error)
 	Destroy(r interface{}) ([]byte, error)
 }

--- a/pkg/services/legal_values/legal_values.go
+++ b/pkg/services/legal_values/legal_values.go
@@ -35,8 +35,10 @@ func (svc *LegalValuesService) Query(address string, outShape interface{}) error
 		return err
 	}
 
-	if err := json.Unmarshal(respBytes, outShape); err != nil {
-		return errors.New("Unable to unpack response")
+	for _, respByte := range respBytes {
+		if err := json.Unmarshal(respByte, outShape); err != nil {
+			return errors.New("Unable to unpack response")
+		}
 	}
 
 	return nil

--- a/pkg/services/legal_values/legal_values_test.go
+++ b/pkg/services/legal_values/legal_values_test.go
@@ -16,15 +16,16 @@ func TestGetLegalValues(t *testing.T) {
 	}{
 		"retrieves list of legal values": {
 			TestClient: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]map[string]string{{"key": "key", "value": "value"}, {"key": "key2", "value": "value2"}})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]map[string]string{{"key": "key", "value": "value"}, {"key": "key2", "value": "value2"}})
+					return [][]byte{b}, err
 				},
 			},
 			ExpectedOut: []map[string]string{{"key": "key", "value": "value"}, {"key": "key2", "value": "value2"}},
 		},
 		"returns an empty array and error when api call fails": {
 			TestClient: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
+				ReadFunc: func(r interface{}) ([][]byte, error) {
 					return nil, errors.New("error")
 				},
 			},
@@ -33,8 +34,9 @@ func TestGetLegalValues(t *testing.T) {
 		},
 		"returns an empty array and error when api response is not expected shape": {
 			TestClient: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(map[string]string{"key": "key"})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(map[string]string{"key": "key"})
+					return [][]byte{b}, err
 				},
 			},
 			ExpectedOut: []map[string]string{},

--- a/pkg/services/privileges/privileges_test.go
+++ b/pkg/services/privileges/privileges_test.go
@@ -21,8 +21,9 @@ func TestQuery(t *testing.T) {
 			queryPayload:     &PrivilegeQuery{Limit: "1"},
 			expectedResponse: []Privilege{Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("privilege")}},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]Privilege{Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("privilege")}})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]Privilege{Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("privilege")}})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -33,11 +34,12 @@ func TestQuery(t *testing.T) {
 				Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("name2")},
 			},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]Privilege{
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]Privilege{
 						Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("privilege")},
 						Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("name2")},
 					})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -71,15 +73,18 @@ func TestQueryWithAssignments(t *testing.T) {
 			queryPayload:     &PrivilegeQuery{Limit: "1"},
 			expectedResponse: []Privilege{Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("privilege"), RoleIDs: []int{1, 2, 3}, UserIDs: []int{5, 6, 7}}},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]Privilege{Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("privilege")}})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]Privilege{Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("privilege")}})
+					return [][]byte{b}, err
 				},
-				ReReadFunc: []func(r interface{}) ([]byte, error){
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 4, "roles": []int{1, 2, 3}})
+				ReReadFunc: []func(r interface{}) ([][]byte, error){
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 4, "roles": []int{1, 2, 3}})
+						return [][]byte{b}, err
 					},
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 4, "users": []int{5, 6, 7}})
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 4, "users": []int{5, 6, 7}})
+						return [][]byte{b}, err
 					},
 				},
 			},
@@ -91,24 +96,29 @@ func TestQueryWithAssignments(t *testing.T) {
 				Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("name2"), UserIDs: []int{5, 6, 7}, RoleIDs: []int{1, 2, 3}},
 			},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]Privilege{
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]Privilege{
 						Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("privilege")},
 						Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("name2")},
 					})
+					return [][]byte{b}, err
 				},
-				ReReadFunc: []func(r interface{}) ([]byte, error){
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 4, "roles": []int{1, 2, 3}})
+				ReReadFunc: []func(r interface{}) ([][]byte, error){
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 4, "roles": []int{1, 2, 3}})
+						return [][]byte{b}, err
 					},
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 4, "users": []int{5, 6, 7}})
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 4, "users": []int{5, 6, 7}})
+						return [][]byte{b}, err
 					},
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 4, "roles": []int{1, 2, 3}})
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 4, "roles": []int{1, 2, 3}})
+						return [][]byte{b}, err
 					},
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 4, "users": []int{5, 6, 7}})
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 4, "users": []int{5, 6, 7}})
+						return [][]byte{b}, err
 					},
 				},
 			},
@@ -121,24 +131,28 @@ func TestQueryWithAssignments(t *testing.T) {
 			},
 			expectedError: []error{errors.New("unable to read [users]"), nil},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]Privilege{
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]Privilege{
 						Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("privilege")},
 						Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("name2")},
 					})
+					return [][]byte{b}, err
 				},
-				ReReadFunc: []func(r interface{}) ([]byte, error){
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 4, "roles": []int{1, 2, 3}})
+				ReReadFunc: []func(r interface{}) ([][]byte, error){
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 4, "roles": []int{1, 2, 3}})
+						return [][]byte{b}, err
 					},
-					func(r interface{}) ([]byte, error) {
-						return []byte{}, errors.New("fail")
+					func(r interface{}) ([][]byte, error) {
+						return [][]byte{}, errors.New("fail")
 					},
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 4, "roles": []int{1, 2, 3}})
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 4, "roles": []int{1, 2, 3}})
+						return [][]byte{b}, err
 					},
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 4, "users": []int{5, 6, 7}})
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 4, "users": []int{5, 6, 7}})
+						return [][]byte{b}, err
 					},
 				},
 			},
@@ -173,15 +187,18 @@ func TestGetOne(t *testing.T) {
 			id:               "asdf",
 			expectedResponse: &Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("first"), RoleIDs: []int{1, 2, 3}, UserIDs: []int{5, 6, 7}},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("first")})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("first")})
+					return [][]byte{b}, err
 				},
-				ReReadFunc: []func(r interface{}) ([]byte, error){
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 4, "roles": []int{1, 2, 3}})
+				ReReadFunc: []func(r interface{}) ([][]byte, error){
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 4, "roles": []int{1, 2, 3}})
+						return [][]byte{b}, err
 					},
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 4, "users": []int{5, 6, 7}})
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 4, "users": []int{5, 6, 7}})
+						return [][]byte{b}, err
 					},
 				},
 			},
@@ -190,15 +207,17 @@ func TestGetOne(t *testing.T) {
 			id:               "asdf",
 			expectedResponse: &Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("first")},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("first")})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("first")})
+					return [][]byte{b}, err
 				},
-				ReReadFunc: []func(r interface{}) ([]byte, error){
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 4, "garbage": 123})
+				ReReadFunc: []func(r interface{}) ([][]byte, error){
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 4, "garbage": 123})
+						return [][]byte{b}, err
 					},
-					func(r interface{}) ([]byte, error) {
-						return []byte{}, errors.New("fail")
+					func(r interface{}) ([][]byte, error) {
+						return [][]byte{}, errors.New("fail")
 					},
 				},
 			},
@@ -235,15 +254,18 @@ func TestUpdate(t *testing.T) {
 				UpdateFunc: func(r interface{}) ([]byte, error) {
 					return json.Marshal(Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("update")})
 				},
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("update")})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("update")})
+					return [][]byte{b}, err
 				},
-				ReReadFunc: []func(r interface{}) ([]byte, error){
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 0, "roles": []int{}})
+				ReReadFunc: []func(r interface{}) ([][]byte, error){
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 0, "roles": []int{}})
+						return [][]byte{b}, err
 					},
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 0, "users": []int{}})
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 0, "users": []int{}})
+						return [][]byte{b}, err
 					},
 				},
 			},
@@ -255,15 +277,18 @@ func TestUpdate(t *testing.T) {
 				UpdateFunc: func(r interface{}) ([]byte, error) {
 					return json.Marshal(Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("update")})
 				},
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("update")})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("update")})
+					return [][]byte{b}, err
 				},
-				ReReadFunc: []func(r interface{}) ([]byte, error){
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 0, "roles": []int{}})
+				ReReadFunc: []func(r interface{}) ([][]byte, error){
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 0, "roles": []int{}})
+						return [][]byte{b}, err
 					},
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 0, "users": []int{}})
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 0, "users": []int{}})
+						return [][]byte{b}, err
 					},
 				},
 				CreateFunc: func(r interface{}) ([]byte, error) {
@@ -283,15 +308,18 @@ func TestUpdate(t *testing.T) {
 				UpdateFunc: func(r interface{}) ([]byte, error) {
 					return json.Marshal(Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("update")})
 				},
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("update")})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("update")})
+					return [][]byte{b}, err
 				},
-				ReReadFunc: []func(r interface{}) ([]byte, error){
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 0, "roles": []int{}})
+				ReReadFunc: []func(r interface{}) ([][]byte, error){
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 0, "roles": []int{}})
+						return [][]byte{b}, err
 					},
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 1, "users": []int{1}})
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 1, "users": []int{1}})
+						return [][]byte{b}, err
 					},
 				},
 				CreateFunc: func(r interface{}) ([]byte, error) {
@@ -314,15 +342,18 @@ func TestUpdate(t *testing.T) {
 				UpdateFunc: func(r interface{}) ([]byte, error) {
 					return json.Marshal(Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("update")})
 				},
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("update")})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(Privilege{ID: oltypes.String("asdf"), Name: oltypes.String("update")})
+					return [][]byte{b}, err
 				},
-				ReReadFunc: []func(r interface{}) ([]byte, error){
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 0, "roles": []int{}})
+				ReReadFunc: []func(r interface{}) ([][]byte, error){
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 0, "roles": []int{}})
+						return [][]byte{b}, err
 					},
-					func(r interface{}) ([]byte, error) {
-						return json.Marshal(map[string]interface{}{"total": 1, "users": []int{1}})
+					func(r interface{}) ([][]byte, error) {
+						b, err := json.Marshal(map[string]interface{}{"total": 1, "users": []int{1}})
+						return [][]byte{b}, err
 					},
 				},
 				DestroyFunc: func(r interface{}) ([]byte, error) {

--- a/pkg/services/roles/roles_test.go
+++ b/pkg/services/roles/roles_test.go
@@ -20,8 +20,9 @@ func TestQuery(t *testing.T) {
 			queryPayload:     &RoleQuery{Limit: "1"},
 			expectedResponse: []Role{Role{ID: oltypes.Int32(123), Name: oltypes.String("my_role")}},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]Role{Role{ID: oltypes.Int32(123), Name: oltypes.String("my_role")}})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]Role{Role{ID: oltypes.Int32(123), Name: oltypes.String("my_role")}})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -32,11 +33,12 @@ func TestQuery(t *testing.T) {
 				Role{ID: oltypes.Int32(123), Name: oltypes.String("my_role")},
 			},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]Role{
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]Role{
 						Role{ID: oltypes.Int32(123), Name: oltypes.String("my_role")},
 						Role{ID: oltypes.Int32(123), Name: oltypes.String("my_role")},
 					})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -70,8 +72,9 @@ func TestGetOne(t *testing.T) {
 			id:               123,
 			expectedResponse: &Role{ID: oltypes.Int32(123), Name: oltypes.String("my_role")},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(Role{ID: oltypes.Int32(123), Name: oltypes.String("my_role")})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(Role{ID: oltypes.Int32(123), Name: oltypes.String("my_role")})
+					return [][]byte{b}, err
 				},
 			},
 		},

--- a/pkg/services/roles/v1.go
+++ b/pkg/services/roles/v1.go
@@ -39,7 +39,11 @@ func (svc *V1Service) Query(query *RoleQuery) ([]Role, error) {
 	}
 
 	var roles []Role
-	json.Unmarshal(resp, &roles)
+	for _, bytes := range resp {
+		var unmarshalled []Role
+		json.Unmarshal(bytes, &unmarshalled)
+		roles = append(roles, unmarshalled...)
+	}
 	return roles, nil
 }
 
@@ -54,7 +58,12 @@ func (svc *V1Service) GetOne(id int32) (*Role, error) {
 		return nil, err
 	}
 	var role Role
-	json.Unmarshal(resp, &role)
+
+	if len(resp) < 1 {
+		return nil, errors.New("invalid length of response returned")
+	}
+
+	json.Unmarshal(resp[0], &role)
 	return &role, nil
 }
 

--- a/pkg/services/smarthooks/envs/envs_test.go
+++ b/pkg/services/smarthooks/envs/envs_test.go
@@ -22,8 +22,9 @@ func TestQuery(t *testing.T) {
 			queryPayload:     &SmartHookEnvVarQuery{Limit: "abc"},
 			expectedResponse: []EnvVar{EnvVar{ID: oltypes.String("abc"), Name: oltypes.String("API_KEY"), Value: oltypes.String("Its a secret to everybody")}},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]EnvVar{EnvVar{ID: oltypes.String("abc"), Name: oltypes.String("API_KEY"), Value: oltypes.String("Its a secret to everybody")}})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]EnvVar{EnvVar{ID: oltypes.String("abc"), Name: oltypes.String("API_KEY"), Value: oltypes.String("Its a secret to everybody")}})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -34,11 +35,12 @@ func TestQuery(t *testing.T) {
 				EnvVar{ID: oltypes.String("abc"), Name: oltypes.String("API_KEY"), Value: oltypes.String("Its a secret to everybody")},
 			},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]EnvVar{
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]EnvVar{
 						EnvVar{ID: oltypes.String("abc"), Name: oltypes.String("API_KEY"), Value: oltypes.String("Its a secret to everybody")},
 						EnvVar{ID: oltypes.String("abc"), Name: oltypes.String("API_KEY"), Value: oltypes.String("Its a secret to everybody")},
 					})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -72,8 +74,9 @@ func TestGetOne(t *testing.T) {
 			id:               "abc",
 			expectedResponse: &EnvVar{ID: oltypes.String("abc"), Name: oltypes.String("API_KEY"), Value: oltypes.String("Its a secret to everybody")},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(EnvVar{ID: oltypes.String("abc"), Name: oltypes.String("API_KEY"), Value: oltypes.String("Its a secret to everybody")})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(EnvVar{ID: oltypes.String("abc"), Name: oltypes.String("API_KEY"), Value: oltypes.String("Its a secret to everybody")})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -119,11 +122,12 @@ func TestUpdate(t *testing.T) {
 					fmt.Println("UP")
 					return json.Marshal(EnvVar{ID: oltypes.String("def"), Name: oltypes.String("API_KEY")})
 				},
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]EnvVar{
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]EnvVar{
 						EnvVar{ID: oltypes.String("abc"), Name: oltypes.String("SECRET")},
 						EnvVar{ID: oltypes.String("def"), Name: oltypes.String("API_KEY")},
 					})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -136,8 +140,9 @@ func TestUpdate(t *testing.T) {
 					fmt.Println("UP")
 					return json.Marshal(EnvVar{ID: oltypes.String("def"), Name: oltypes.String("API_KEY")})
 				},
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]EnvVar{})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]EnvVar{})
+					return [][]byte{b}, err
 				},
 			},
 		},

--- a/pkg/services/smarthooks/envs/v1.go
+++ b/pkg/services/smarthooks/envs/v1.go
@@ -40,7 +40,11 @@ func (svc *V1Service) Query(query *SmartHookEnvVarQuery) ([]EnvVar, error) {
 	}
 
 	var envVars []EnvVar
-	json.Unmarshal(resp, &envVars)
+	for _, bytes := range resp {
+		var unmarshalled []EnvVar
+		json.Unmarshal(bytes, &unmarshalled)
+		envVars = append(envVars, unmarshalled...)
+	}
 	return envVars, nil
 }
 
@@ -55,7 +59,12 @@ func (svc *V1Service) GetOne(id string) (*EnvVar, error) {
 	if err != nil {
 		return &out, err
 	}
-	json.Unmarshal(resp, &out)
+
+	if len(resp) < 1 {
+		return nil, errors.New("invalid length of response returned")
+	}
+
+	json.Unmarshal(resp[0], &out)
 	return &out, nil
 }
 

--- a/pkg/services/smarthooks/smarthooks_test.go
+++ b/pkg/services/smarthooks/smarthooks_test.go
@@ -20,8 +20,9 @@ func TestQuery(t *testing.T) {
 			queryPayload:     &SmartHookQuery{Limit: "1"},
 			expectedResponse: []SmartHook{SmartHook{ID: oltypes.String("abc"), Function: oltypes.String("ZnVuY3Rpb24gbXlGdW5jKCkgey4uLn0=")}},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]SmartHook{SmartHook{ID: oltypes.String("abc"), Function: oltypes.String("ZnVuY3Rpb24gbXlGdW5jKCkgey4uLn0=")}})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]SmartHook{SmartHook{ID: oltypes.String("abc"), Function: oltypes.String("ZnVuY3Rpb24gbXlGdW5jKCkgey4uLn0=")}})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -32,11 +33,12 @@ func TestQuery(t *testing.T) {
 				SmartHook{ID: oltypes.String("abc"), Function: oltypes.String("ZnVuY3Rpb24gbXlPdGhlckZ1bmMoKSB7Li4ufQ==")},
 			},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]SmartHook{
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]SmartHook{
 						SmartHook{ID: oltypes.String("abc"), Function: oltypes.String("ZnVuY3Rpb24gbXlGdW5jKCkgey4uLn0=")},
 						SmartHook{ID: oltypes.String("abc"), Function: oltypes.String("ZnVuY3Rpb24gbXlPdGhlckZ1bmMoKSB7Li4ufQ==")},
 					})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -70,8 +72,9 @@ func TestGetOne(t *testing.T) {
 			id:               "1",
 			expectedResponse: &SmartHook{ID: oltypes.String("abc"), Function: oltypes.String("ZnVuY3Rpb24gbXlGdW5jKCkgey4uLn0=")},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(SmartHook{ID: oltypes.String("abc"), Function: oltypes.String("ZnVuY3Rpb24gbXlGdW5jKCkgey4uLn0=")})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(SmartHook{ID: oltypes.String("abc"), Function: oltypes.String("ZnVuY3Rpb24gbXlGdW5jKCkgey4uLn0=")})
+					return [][]byte{b}, err
 				},
 			},
 		},

--- a/pkg/services/smarthooks/v1.go
+++ b/pkg/services/smarthooks/v1.go
@@ -44,7 +44,11 @@ func (svc *V1Service) Query(query *SmartHookQuery) ([]SmartHook, error) {
 	}
 
 	var smarthooks []SmartHook
-	json.Unmarshal(resp, &smarthooks)
+	for _, bytes := range resp {
+		var unmarshalled []SmartHook
+		json.Unmarshal(bytes, &unmarshalled)
+		smarthooks = append(smarthooks, unmarshalled...)
+	}
 	return smarthooks, nil
 }
 
@@ -59,7 +63,12 @@ func (svc *V1Service) GetOne(id string) (*SmartHook, error) {
 	if err != nil {
 		return &out, err
 	}
-	json.Unmarshal(resp, &out)
+
+	if len(resp) < 1 {
+		return nil, errors.New("invalid length of response returned")
+	}
+
+	json.Unmarshal(resp[0], &out)
 	return &out, nil
 }
 

--- a/pkg/services/user_mappings/user_mappings_test.go
+++ b/pkg/services/user_mappings/user_mappings_test.go
@@ -35,8 +35,9 @@ func TestQuery(t *testing.T) {
 				UserMapping{ID: oltypes.Int32(1), Name: oltypes.String("mapping")},
 			},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]UserMapping{UserMapping{ID: oltypes.Int32(1), Name: oltypes.String("mapping")}})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]UserMapping{UserMapping{ID: oltypes.Int32(1), Name: oltypes.String("mapping")}})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -47,11 +48,12 @@ func TestQuery(t *testing.T) {
 				UserMapping{ID: oltypes.Int32(1), Name: oltypes.String("name2")},
 			},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]UserMapping{
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]UserMapping{
 						UserMapping{ID: oltypes.Int32(1), Name: oltypes.String("name")},
 						UserMapping{ID: oltypes.Int32(1), Name: oltypes.String("name2")},
 					})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -65,8 +67,9 @@ func TestQuery(t *testing.T) {
 			queryPayload:     &UserMappingsQuery{HasAction: "???"},
 			expectedResponse: []UserMapping{},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]UserMapping{})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]UserMapping{})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -94,8 +97,9 @@ func TestGetOne(t *testing.T) {
 			id:               int32(1),
 			expectedResponse: &UserMapping{ID: oltypes.Int32(1), Name: oltypes.String("name")},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(UserMapping{ID: oltypes.Int32(1), Name: oltypes.String("name")})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(UserMapping{ID: oltypes.Int32(1), Name: oltypes.String("name")})
+					return [][]byte{b}, err
 				},
 			},
 		},

--- a/pkg/services/user_mappings/v2.go
+++ b/pkg/services/user_mappings/v2.go
@@ -47,7 +47,15 @@ func (svc *V2Service) Query(query *UserMappingsQuery) ([]UserMapping, error) {
 	}
 
 	var userMappings []UserMapping
-	json.Unmarshal(resp, &userMappings)
+	for _, bytes := range resp {
+		var unmarshalled []UserMapping
+		json.Unmarshal(bytes, &unmarshalled)
+		if len(userMappings) == 0 {
+			userMappings = unmarshalled
+		} else {
+			userMappings = append(userMappings, unmarshalled...)
+		}
+	}
 
 	return userMappings, nil
 }
@@ -65,7 +73,11 @@ func (svc *V2Service) GetOne(id int32) (*UserMapping, error) {
 	}
 
 	var mapping UserMapping
-	json.Unmarshal(resp, &mapping)
+
+	if len(resp) < 1 {
+		return nil, errors.New("invalid length of response returned")
+	}
+	json.Unmarshal(resp[0], &mapping)
 
 	return &mapping, nil
 }

--- a/pkg/services/users/users_test.go
+++ b/pkg/services/users/users_test.go
@@ -20,8 +20,9 @@ func TestQuery(t *testing.T) {
 			queryPayload:     &UserQuery{Limit: "1"},
 			expectedResponse: []User{User{ID: oltypes.Int32(1), Firstname: oltypes.String("name")}},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]User{User{ID: oltypes.Int32(1), Firstname: oltypes.String("name")}})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]User{User{ID: oltypes.Int32(1), Firstname: oltypes.String("name")}})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -32,11 +33,12 @@ func TestQuery(t *testing.T) {
 				User{ID: oltypes.Int32(1), Firstname: oltypes.String("name2")},
 			},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal([]User{
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal([]User{
 						User{ID: oltypes.Int32(1), Firstname: oltypes.String("name")},
 						User{ID: oltypes.Int32(1), Firstname: oltypes.String("name2")},
 					})
+					return [][]byte{b}, err
 				},
 			},
 		},
@@ -70,8 +72,9 @@ func TestGetOne(t *testing.T) {
 			id:               int32(1),
 			expectedResponse: &User{ID: oltypes.Int32(1), Firstname: oltypes.String("first")},
 			repository: &test.MockRepository{
-				ReadFunc: func(r interface{}) ([]byte, error) {
-					return json.Marshal(User{ID: oltypes.Int32(1), Firstname: oltypes.String("first")})
+				ReadFunc: func(r interface{}) ([][]byte, error) {
+					b, err := json.Marshal(User{ID: oltypes.Int32(1), Firstname: oltypes.String("first")})
+					return [][]byte{b}, err
 				},
 			},
 		},

--- a/pkg/services/users/v2.go
+++ b/pkg/services/users/v2.go
@@ -37,9 +37,16 @@ func (svc *V2Service) Query(query *UserQuery) ([]User, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	var users []User
-	json.Unmarshal(resp, &users)
+	for _, bytes := range resp {
+		var unmarshalled []User
+		json.Unmarshal(bytes, &unmarshalled)
+		if len(users) == 0 {
+			users = unmarshalled
+		} else {
+			users = append(users, unmarshalled...)
+		}
+	}
 	return users, nil
 }
 
@@ -54,7 +61,11 @@ func (svc *V2Service) GetOne(id int32) (*User, error) {
 		return nil, err
 	}
 	var user User
-	json.Unmarshal(resp, &user)
+
+	if len(resp) < 1 {
+		return nil, errors.New("invalid length of response returned")
+	}
+	json.Unmarshal(resp[0], &user)
 	return &user, nil
 }
 


### PR DESCRIPTION
I tried using your SDK, which did not work at all.

Pagination issues: when a list of users is retrieved, the current implementation **WAS NOT WORKING!**. The last page result set was returned at all times, NOT accomulating the previously retrieved results. Please check the code comments for more details...

Issues identified:
- The result set in users (allData) was not being returned
- Incorrect appending of returned Json values (when result sets are arrays, appending bytes **does not work!**
- Querying Onelogin with a "Cursor" parameter returns a server error as it is invalid. It should start with lowercase.