### PR TITLE
Fix panic when paginating reads.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 	go build './...'
 
 test:
-	go get github.com/jpoles1/gopherbadger
+	go install github.com/jpoles1/gopherbadger@v2.4.0+incompatible
 	gopherbadger -md="readme.md" -png=false
 
 secure:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 	go build './...'
 
 test:
-	go install github.com/jpoles1/gopherbadger@v2.4.0+incompatible
+	go install github.com/jpoles1/gopherbadger@v2.4.0
 	gopherbadger -md="readme.md" -png=false
 
 secure:

--- a/pkg/services/olhttp/olrequest.go
+++ b/pkg/services/olhttp/olrequest.go
@@ -5,14 +5,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/onelogin/onelogin-go-sdk/internal/customerrors"
-	"github.com/onelogin/onelogin-go-sdk/pkg/services"
-	"github.com/onelogin/onelogin-go-sdk/pkg/utils"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/onelogin/onelogin-go-sdk/internal/customerrors"
+	"github.com/onelogin/onelogin-go-sdk/pkg/services"
+	"github.com/onelogin/onelogin-go-sdk/pkg/utils"
 )
 
 const resourceRequestuestContext = "ol http service"
@@ -75,13 +76,13 @@ func (svc OLHTTPService) Read(r interface{}) ([][]byte, error) {
 			break
 		}
 		params := req.URL.Query()
-		params.Add("cursor", next)
+		params.Set("cursor", next)
 		req.URL.RawQuery = params.Encode()
 		resp, data, err = svc.executeHTTP(req, resourceRequest)
-	}
 
-	if err != nil {
-		return [][]byte{}, err
+		if err != nil {
+			return [][]byte{}, err
+		}
 	}
 	return allData, err
 }


### PR DESCRIPTION
* Set the cursor header instead of add, so that multiple requests to load all items will not add n cursor query parameters
* Fix the location of error checking after using the cursor to load more items in a paginated read, so that it doesn't panic.
* Fix a few minor warnings with tests
* Fix a deprecation issue with `make test`