### PR TITLE
Update to use subdomain rather than region

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@
       Timeout:      5,
       ClientID:     "your_onelogin_developer_client_id",
       ClientSecret: "your_onelogin_developer_client_secret",
-      Region:       "us",
+      Url:       "https://<your-subdomain>.onelogin.com",
     })
     if err != nil {
       // handle error


### PR DESCRIPTION
Region based endpoint is only being allowed for backwards compatibility. Use subdomain going forward.