### PR TITLE
Enable payload on Destroy method

### DIFF
--- a/pkg/services/olhttp/olrequest.go
+++ b/pkg/services/olhttp/olrequest.go
@@ -137,7 +137,19 @@ func (svc OLHTTPService) Update(r interface{}) ([]byte, error) {
 // Destroy executes a HTTP destroy and removes the resource from its location in a remote
 func (svc OLHTTPService) Destroy(r interface{}) ([]byte, error) {
 	resourceRequest := r.(OLHTTPRequest)
-	req, reqErr := http.NewRequest(http.MethodDelete, resourceRequest.URL, nil)
+	var (
+		req    *http.Request
+		reqErr error
+	)
+	if resourceRequest.Payload != nil {
+		bodyToSend, marshErr := json.Marshal(resourceRequest.Payload)
+		if marshErr != nil {
+			return nil, customerrors.OneloginErrorWrapper(resourceRequestuestContext, marshErr)
+		}
+		req, reqErr = http.NewRequest(http.MethodDelete, resourceRequest.URL, bytes.NewBuffer(bodyToSend))
+	} else {
+		req, reqErr = http.NewRequest(http.MethodDelete, resourceRequest.URL, nil)
+	}
 	if reqErr != nil {
 		return nil, customerrors.OneloginErrorWrapper(resourceRequestuestContext, reqErr)
 	}


### PR DESCRIPTION
## Background

* Some onelogin  DELETE api requires payload parameter
    * e.g. https://developers.onelogin.com/api-docs/2/roles/remove-role-users
    * this api respond error when payload is not set. 
* However current sdk(v1)  `Destroy` method  discards payload
* This PR adds payload handler

## How it work

create role attachment (This works on current released version)
```
    payload := make([]int32, userIDs.(*schema.Set).Len())
      for i, userID := range userIDs.(*schema.Set).List() {
          payload[i] = int32(userID.(int))
      }
      
     svc := client.Services.RolesV1
     _, err := svc.Repository.Create(olhttp.OLHTTPRequest{
		URL:        fmt.Sprintf("%s/%d/users", svc.Endpoint, int32(roleID.(int))),
		Headers:    map[string]string{"Content-Type": "application/json"},
		AuthMethod: "bearer",
		Payload:    &payload,
    })
```

and delete (This PR make it enable)
```
	_, err := svc.Repository.Destroy(olhttp.OLHTTPRequest{
		URL:        fmt.Sprintf("%s/%d/users", svc.Endpoint, int32(roleID.(int))),
		Headers:    map[string]string{"Content-Type": "application/json"},
		AuthMethod: "bearer",
		Payload:    &payload,
	})
```