### PR TITLE
fix unmarshal json issue when setting user

### DIFF
--- a/pkg/onelogin/utilities/web.go
+++ b/pkg/onelogin/utilities/web.go
@@ -108,9 +108,12 @@ func queryToValues(query interface{}) (url.Values, error) {
 		if err != nil {
 			return nil, err
 		}
-		err = json.Unmarshal(queryBytes, &values)
-		if err != nil {
+		var data map[string]string
+		if err := json.Unmarshal(queryBytes, &data); err != nil {
 			return nil, err
+		}
+		for key, value := range data {
+			values.Set(key, value)
 		}
 	}
 


### PR DESCRIPTION
Context: https://github.com/onelogin/onelogin-go-sdk/issues/79

When setting UserQuery params GetUsers throw an error Failed to get user: json: cannot unmarshal string into Go value of type []string
