### PR TITLE
DEVEX-1619 Fix adding admins and users for roles api call

### DIFF
--- a/pkg/onelogin/roles.go
+++ b/pkg/onelogin/roles.go
@@ -83,12 +83,12 @@ func (sdk *OneloginSDK) GetRoleUsers(roleID int, queryParams mod.Queryable) (int
 	return utl.CheckHTTPResponse(resp)
 }
 
-func (sdk *OneloginSDK) AddRoleUsers(roleID int) (interface{}, error) {
+func (sdk *OneloginSDK) AddRoleUsers(roleID int, users []int) (interface{}, error) {
 	p, err := utl.BuildAPIPath(RolePath, roleID, "users")
 	if err != nil {
 		return nil, err
 	}
-	resp, err := sdk.Client.Put(&p, nil)
+	resp, err := sdk.Client.Post(&p, users)
 	if err != nil {
 		return nil, err
 	}
@@ -120,12 +120,12 @@ func (sdk *OneloginSDK) GetRoleAdmins(roleID int) (interface{}, error) {
 	return utl.CheckHTTPResponse(resp)
 }
 
-func (sdk *OneloginSDK) AddRoleAdmins(roleID int) (interface{}, error) {
+func (sdk *OneloginSDK) AddRoleAdmins(roleID int, admins []int) (interface{}, error) {
 	p, err := utl.BuildAPIPath(RolePath, roleID, "admins")
 	if err != nil {
 		return nil, err
 	}
-	resp, err := sdk.Client.Put(&p, nil)
+	resp, err := sdk.Client.Post(&p, admins)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### DEVEX-1619 Fix adding admins and users for roles api call


### Test using following Golang code
```
package main

import (
      "fmt"
      "os"

      "github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin"
      "github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/models"
)

func main() {

      os.Setenv("ONELOGIN_CLIENT_ID", "client_id")
      os.Setenv("ONELOGIN_CLIENT_SECRET", "client secret")
      os.Setenv("ONELOGIN_SUBDOMAIN", "subdomain")
      os.Setenv("ONELOGIN_TIMEOUT", "15")

      ol, err := onelogin.NewOneloginSDK()
      if err != nil {
            fmt.Println("Unable to initialize client:", err)
            return
      }

      users := []int{1234}                // replace 1234 with actual user id
      apiResp, err := ol.AddRoleUsers(4321, users)          // replace 4321 with actual role id
      if err != nil {
            fmt.Println("Failed to add users to role:", err)
            return
      }
      fmt.Println("Response:", apiResp)
}
```

