### PR TITLE
Fix malformed path for get groups request

### DIFF
--- a/pkg/onelogin/groups.go
+++ b/pkg/onelogin/groups.go
@@ -19,7 +19,10 @@ func (sdk *OneloginSDK) GetGroupByID(groupID int) (interface{}, error) {
 }
 
 func (sdk *OneloginSDK) GetGroups() (interface{}, error) {
-	p := GroupsPath
+	p, err := utl.BuildAPIPath(GroupsPath)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := sdk.Client.Get(&p, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Attach the construction of the API path, to avoid missing leading `/`.

This fixes:
```
Get \"https://{subdomain}.onelogin.comapi/1/groups\": dial tcp: lookup {subdomain}.onelogin.comapi on 127.0.0.11:53: no such host
```