### PR TITLE
Fix User.ManagerADID type

### DIFF
--- a/pkg/onelogin/models/user.go
+++ b/pkg/onelogin/models/user.go
@@ -62,6 +62,7 @@ type User struct {
 	Title                string                 `json:"title,omitempty"`
 	Company              string                 `json:"company,omitempty"`
 	Department           string                 `json:"department,omitempty"`
+	ManagerADID          string                 `json:"manager_ad_id,omitempty"`
 	Comment              string                 `json:"comment,omitempty"`
 	CreatedAt            time.Time              `json:"created_at,omitempty"`
 	UpdatedAt            time.Time              `json:"updated_at,omitempty"`
@@ -76,7 +77,6 @@ type User struct {
 	GroupID              int32                  `json:"group_id,omitempty"`
 	DirectoryID          int32                  `json:"directory_id,omitempty"`
 	TrustedIDPID         int32                  `json:"trusted_idp_id,omitempty"`
-	ManagerADID          int32                  `json:"manager_ad_id,omitempty"`
 	ManagerUserID        int32                  `json:"manager_user_id,omitempty"`
 	ExternalID           int32                  `json:"external_id,omitempty"`
 	ID                   int32                  `json:"id,omitempty"`


### PR DESCRIPTION
When using the same approach used by the SDK with the [json.Unmarshal](https://pkg.go.dev/encoding/json#Unmarshal)
it fails with:
```
cannot unmarshal string into Go struct field User.manager_ad_id of type int32
```

While looking at the API response raw data, I've noticed the `manager_ad_id`
comes with "embedded" double-quotes `"` in the json, which means this should
be a string. Although that's not so obvious by looking into [the official docs](https://developers.onelogin.com/api-docs/2/users/get-user).

---

Sample code:

```go
import (
    "fmt"
    "json"
    "github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/models"
)

func main() {
    // initialize the `olSvc`
    // ...

    userID := 12313 // the user id
    rawPayload, err := olSvc.GetUserByID(userID, &models.UserQuery{})
    if err != nil {
        fmt.Printf("fail to get user: %s", err)
    }

    var rawUser models.User
    payloadBytes, err := json.Marshal(rawPayload)
    if err != nil {
        fmt.Printf("error pre-decoding users structure: %s", err)
    }

    err = json.Unmarshal(payloadBytes, &rawUser)
    if err != nil {
        fmt.Printf("error decoding users structure: %s", err)
    }
}

// Produces an output of:
// error decoding users structure: cannot unmarshal string into Go struct field User.manager_ad_id of type int32
```