### PR TITLE
Fix custom attribute API handling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [4.3.0]
+
+### Added
+- Helper methods for creating and updating custom attributes with proper payload structure:
+  - Added `CreateCustomAttribute(name, shortname string)` method
+  - Added `UpdateCustomAttribute(id int, name, shortname string)` method
+  - These methods properly wrap parameters in the required "user_field" object
+- Added example code for custom attributes with create, read, update, delete examples
+
+### Fixed
+- Fixed custom attribute creation/update by properly wrapping parameters in the "user_field" object
+- Fixed handling of HTTP 204 No Content responses for operations like delete that return no content on success
+
 ## [4.2.0]
 
 ### Fixed

--- a/pkg/onelogin/users.go
+++ b/pkg/onelogin/users.go
@@ -218,12 +218,68 @@ func (sdk *OneloginSDK) CreateCustomAttributes(requestBody interface{}) (interfa
 	return utl.CheckHTTPResponse(resp)
 }
 
+// CreateCustomAttribute creates a new custom attribute with the specified name and shortname.
+// This helper method properly wraps the name and shortname in the required "user_field" object
+// as expected by the OneLogin API.
+func (sdk *OneloginSDK) CreateCustomAttribute(name, shortname string) (interface{}, error) {
+	return sdk.CreateCustomAttributeWithContext(context.Background(), name, shortname)
+}
+
+// CreateCustomAttributeWithContext creates a new custom attribute with the provided context
+func (sdk *OneloginSDK) CreateCustomAttributeWithContext(ctx context.Context, name, shortname string) (interface{}, error) {
+	// Use map[string]string for the inner map to ensure consistent types
+	payload := map[string]interface{}{
+		"user_field": map[string]string{
+			"name":      name,
+			"shortname": shortname,
+		},
+	}
+
+	p, err := utl.BuildAPIPath(UserPathV2, "custom_attributes")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := sdk.Client.PostWithContext(ctx, &p, payload)
+	if err != nil {
+		return nil, err
+	}
+	return utl.CheckHTTPResponse(resp)
+}
+
 func (sdk *OneloginSDK) UpdateCustomAttributes(id int, requestBody interface{}) (interface{}, error) {
 	p, err := utl.BuildAPIPath(UserPathV2, "custom_attributes", id)
 	if err != nil {
 		return nil, err
 	}
 	resp, err := sdk.Client.Put(&p, requestBody)
+	if err != nil {
+		return nil, err
+	}
+	return utl.CheckHTTPResponse(resp)
+}
+
+// UpdateCustomAttribute updates an existing custom attribute with the specified name and shortname.
+// This helper method properly wraps the name and shortname in the required "user_field" object
+// as expected by the OneLogin API.
+func (sdk *OneloginSDK) UpdateCustomAttribute(id int, name, shortname string) (interface{}, error) {
+	return sdk.UpdateCustomAttributeWithContext(context.Background(), id, name, shortname)
+}
+
+// UpdateCustomAttributeWithContext updates an existing custom attribute with the provided context
+func (sdk *OneloginSDK) UpdateCustomAttributeWithContext(ctx context.Context, id int, name, shortname string) (interface{}, error) {
+	// Use map[string]string for the inner map to ensure consistent types
+	payload := map[string]interface{}{
+		"user_field": map[string]string{
+			"name":      name,
+			"shortname": shortname,
+		},
+	}
+
+	p, err := utl.BuildAPIPath(UserPathV2, "custom_attributes", id)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := sdk.Client.PutWithContext(ctx, &p, payload)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/onelogin/utilities/web.go
+++ b/pkg/onelogin/utilities/web.go
@@ -14,6 +14,11 @@ import (
 // receive http response, check error code status, if good return json of resp.Body
 // else return error
 func CheckHTTPResponse(resp *http.Response) (interface{}, error) {
+	// Handle 204 No Content responses - this is a success but with no content
+	if resp.StatusCode == http.StatusNoContent {
+		return map[string]interface{}{"status": "success"}, nil
+	}
+
 	// Check if the request was successful
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return nil, fmt.Errorf("request failed with status: %d", resp.StatusCode)

--- a/tests/manual/custom_attributes/custom_attributes_example.go
+++ b/tests/manual/custom_attributes/custom_attributes_example.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin"
+)
+
+func main() {
+	// Get credentials from environment variables
+	clientID := os.Getenv("ONELOGIN_CLIENT_ID")
+	clientSecret := os.Getenv("ONELOGIN_CLIENT_SECRET")
+	subdomain := os.Getenv("ONELOGIN_SUBDOMAIN")
+
+	if clientID == "" || clientSecret == "" || subdomain == "" {
+		fmt.Println("Please set ONELOGIN_CLIENT_ID, ONELOGIN_CLIENT_SECRET, and ONELOGIN_SUBDOMAIN environment variables")
+		os.Exit(1)
+	}
+
+	// Set environment variables for SDK initialization
+	os.Setenv("ONELOGIN_CLIENT_ID", clientID)
+	os.Setenv("ONELOGIN_CLIENT_SECRET", clientSecret)
+	os.Setenv("ONELOGIN_SUBDOMAIN", subdomain)
+
+	// Initialize the SDK
+	sdk, err := onelogin.NewOneloginSDK()
+	if err != nil {
+		fmt.Printf("Error initializing SDK: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Example 1: Create a custom attribute using the new helper function
+	fmt.Println("Example 1: Creating a custom attribute")
+
+	// Create with the new helper that properly structures the payload
+	createResp, err := sdk.CreateCustomAttribute("Employee ID", "employee_id")
+	if err != nil {
+		fmt.Printf("Error creating custom attribute: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Custom attribute created successfully: %+v\n", createResp)
+
+	// Extract the ID from the response for later use
+	attr := createResp.(map[string]interface{})
+	attrID := int(attr["id"].(float64))
+	fmt.Printf("Created attribute ID: %d\n", attrID)
+
+	// Example 2: Get all custom attributes
+	fmt.Println("\nExample 2: Get custom attributes")
+	customAttrs, err := sdk.GetCustomAttributes()
+	if err != nil {
+		fmt.Printf("Error getting custom attributes: %v\n", err)
+	} else {
+		fmt.Printf("Custom attributes: %+v\n", customAttrs)
+	}
+
+	// Example 3: Get custom attribute by ID
+	fmt.Println("\nExample 3: Get custom attribute by ID")
+	attrByID, err := sdk.GetCustomAttributeByID(attrID)
+	if err != nil {
+		fmt.Printf("Error getting custom attribute by ID: %v\n", err)
+	} else {
+		fmt.Printf("Custom attribute by ID: %+v\n", attrByID)
+	}
+
+	// Example 4: Update the custom attribute
+	fmt.Println("\nExample 4: Update custom attribute")
+	updateResp, err := sdk.UpdateCustomAttribute(attrID, "Employee Number", "employee_id")
+	if err != nil {
+		fmt.Printf("Error updating custom attribute: %v\n", err)
+	} else {
+		fmt.Printf("Custom attribute updated successfully: %+v\n", updateResp)
+	}
+
+	// Verify the update
+	updatedAttr, err := sdk.GetCustomAttributeByID(attrID)
+	if err != nil {
+		fmt.Printf("Error getting updated custom attribute: %v\n", err)
+	} else {
+		fmt.Printf("Updated custom attribute: %+v\n", updatedAttr)
+	}
+
+	// Example 5: Delete the custom attribute
+	fmt.Println("\nExample 5: Delete custom attribute")
+	deleteResp, err := sdk.DeleteCustomAttributes(attrID)
+	if err != nil {
+		fmt.Printf("Error deleting custom attribute: %v\n", err)
+	} else {
+		fmt.Printf("Custom attribute deleted successfully: %+v\n", deleteResp)
+	}
+
+	// Verify the deletion
+	fmt.Println("\nVerifying deletion - get all custom attributes")
+	remainingAttrs, err := sdk.GetCustomAttributes()
+	if err != nil {
+		fmt.Printf("Error getting remaining custom attributes: %v\n", err)
+	} else {
+		fmt.Printf("Remaining custom attributes: %+v\n", remainingAttrs)
+
+		// Check if our deleted attribute is still in the list
+		deleted := true
+		attrs := remainingAttrs.([]interface{})
+		for _, a := range attrs {
+			attr, ok := a.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			if id, exists := attr["id"]; exists && int(id.(float64)) == attrID {
+				deleted = false
+				break
+			}
+		}
+
+		if deleted {
+			fmt.Println("✅ Attribute was successfully deleted!")
+		} else {
+			fmt.Println("❌ Attribute was NOT successfully deleted!")
+		}
+	}
+
+	fmt.Println("\nExamples completed")
+}

--- a/tests/manual/custom_attributes/run_custom_attributes_test.sh
+++ b/tests/manual/custom_attributes/run_custom_attributes_test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Set this to your test credentials
+# Or use env variables: ONELOGIN_CLIENT_ID, ONELOGIN_CLIENT_SECRET, ONELOGIN_SUBDOMAIN
+
+cd "$(dirname "$0")"
+echo "Running custom attributes example..."
+go run custom_attributes_example.go


### PR DESCRIPTION
## Summary
- Fix custom attribute creation and update by properly wrapping parameters in the required 'user_field' object
- Add helper methods for creating and updating custom attributes with correct payload structure
- Fix handling of HTTP 204 No Content responses for operations like delete
- Add comprehensive example code demonstrating custom attribute CRUD operations

## Test plan
- Tested creation, retrieval, update, and deletion of custom attributes
- Verified proper error handling and response parsing
- Ensured all Go tools pass (go fmt, go vet, go mod tidy)