### PR TITLE
fix: ensure empty arrays are properly serialized in Role updates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.5.1]
+
+### Fixed
+- Fixed issue with empty arrays in Role updates by ensuring empty arrays are properly serialized in JSON
+- Added documentation example for removing all users from a role
+
 ## [4.5.0]
 
 ### Improved

--- a/docs/usage_examples.md
+++ b/docs/usage_examples.md
@@ -74,6 +74,15 @@ func main() {
 		fmt.Println(err)
 	}
 	fmt.Printf("Updated role: %+v\n", updatedRole)
+	
+	// Remove all users from a role by passing an empty array
+	roleWithNoUsers, err := client.UpdateRole(roleID, &models.Role{
+		Users: []int32{}, // Empty array will remove all users
+	})
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Printf("Updated role with no users: %+v\n", roleWithNoUsers)
 }
 ```
 

--- a/pkg/onelogin/models/role.go
+++ b/pkg/onelogin/models/role.go
@@ -1,5 +1,7 @@
 package models
 
+import "encoding/json"
+
 // RoleQuery represents available query parameters
 type RoleQuery struct {
 	Limit  string `json:"limit,omitempty"`
@@ -7,13 +9,43 @@ type RoleQuery struct {
 	Cursor string `json:"cursor,omitempty"`
 }
 
+// initSlice ensures that a nil slice is initialized as an empty slice
+// This helper is needed for the Role.MarshalJSON method
+func initSlice(s []int32) []int32 {
+	if s == nil {
+		return []int32{}
+	}
+	return s
+}
+
 // Role represents the Role resource in OneLogin
 type Role struct {
 	ID     *int32  `json:"id,omitempty"`
 	Name   *string `json:"name,omitempty"`
-	Admins []int32 `json:"admins,omitempty"`
-	Apps   []int32 `json:"apps,omitempty"`
-	Users  []int32 `json:"users,omitempty"`
+	Admins []int32 `json:"admins"`
+	Apps   []int32 `json:"apps"`
+	Users  []int32 `json:"users"`
+}
+
+// MarshalJSON provides custom JSON marshaling to ensure empty arrays are included in the JSON output
+func (r *Role) MarshalJSON() ([]byte, error) {
+	// Create a map to hold the serialized fields
+	m := make(map[string]interface{})
+	
+	// Add ID and Name if they are not nil
+	if r.ID != nil {
+		m["id"] = *r.ID
+	}
+	if r.Name != nil {
+		m["name"] = *r.Name
+	}
+	
+	// Always include the arrays, even if they're nil (as empty arrays)
+	m["admins"] = initSlice(r.Admins)
+	m["apps"] = initSlice(r.Apps)
+	m["users"] = initSlice(r.Users)
+	
+	return json.Marshal(m)
 }
 
 func (r *Role) GetKeyValidators() map[string]func(interface{}) bool {


### PR DESCRIPTION
This pull request introduces changes to ensure that empty arrays in the `Role` model are properly serialized in JSON, along with updates to documentation and tests. The key changes include implementing a custom `MarshalJSON` method for the `Role` model, adding a helper function to handle slice initialization, updating usage examples, and adding a dedicated test to verify the behavior.

### Serialization Improvements:
* [`pkg/onelogin/models/role.go`](diffhunk://#diff-6ad5f4e61e96debe4026439812222b32d850e133a59606679e5cbfc808960725R3-R48): Added a custom `MarshalJSON` method to the `Role` struct to ensure that empty arrays (`Admins`, `Apps`, `Users`) are always serialized as empty arrays in the JSON output. Introduced the `initSlice` helper function to handle nil slice initialization.

### Documentation Updates:
* [`changelog.md`](diffhunk://#diff-3bd14d078188074c410028847113ceae68865d0ad5b844a27183ef87fbe2fcc3R3-R8): Documented the fix for empty array serialization and added an example for removing all users from a role.
* [`docs/usage_examples.md`](diffhunk://#diff-b7a4d1cb8dd4340daf7529d5e3d00230da76af6c240784f71d5c29ba22497a8fR77-R85): Added a usage example demonstrating how to remove all users from a role by passing an empty array.

### Testing Enhancements:
* [`tests/api_test.go`](diffhunk://#diff-1191345d2e408eb7778eb71e2b875cec9d7511e3ba17858f2df5280b83460a2fR147-R203): Added a new test, `TestRoleEmptyArraysSerialization`, to verify that empty arrays are correctly serialized in JSON, both for explicitly empty slices and nil slices.