### PR TITLE
Add support for self-registration profiles API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@ coverage.out
 bin
 
 **/.claude/settings.local.json
+
+# Environment variables
+.env
+
+# Binary files
+onelogin-go-sdk
+test_self_registration$
+test_mapping

--- a/cmd/test_self_registration/main.go
+++ b/cmd/test_self_registration/main.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/joho/godotenv"
+	"github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin"
+	"github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/models"
+)
+
+func main() {
+	// Load environment variables from .env file
+	err := godotenv.Load()
+	if err != nil {
+		log.Println("Warning: Error loading .env file:", err)
+	}
+
+	// Create a new OneLogin SDK client
+	client, err := onelogin.NewOneloginSDK()
+	if err != nil {
+		log.Fatalf("Error creating OneLogin SDK client: %v", err)
+	}
+
+	// Get all self-registration profiles
+	query := &models.SelfRegistrationProfileQuery{
+		Limit: "10",
+		Page:  "1",
+	}
+	
+	fmt.Println("Fetching self-registration profiles...")
+	profiles, err := client.GetSelfRegistrationProfiles(query)
+	if err != nil {
+		log.Fatalf("Error getting self-registration profiles: %v", err)
+	}
+
+	// Pretty print the profiles
+	profilesJSON, err := json.MarshalIndent(profiles, "", "  ")
+	if err != nil {
+		log.Fatalf("Error marshaling profiles to JSON: %v", err)
+	}
+	fmt.Println("Self-registration profiles:")
+	fmt.Println(string(profilesJSON))
+
+	// Create a new self-registration profile
+	fmt.Println("\nCreating a new self-registration profile...")
+	newProfile := models.SelfRegistrationProfile{
+		Name:                 "Test Profile via SDK",
+		URL:                  "test-profile-sdk-" + os.Getenv("USER"),
+		Enabled:              true,
+		Moderated:            false,
+		DefaultRoleID:        0, // Use a valid role ID from your account
+		Helptext:             "Welcome to our community. Please follow the guidelines.",
+		ThankyouMessage:      "Thank you for joining!",
+		DomainBlacklist:      "spam.com, banned.com",
+		DomainWhitelist:      "example.com, trusted.com",
+		DomainListStrategy:   models.DomainWhitelistStrategy,
+		EmailVerificationType: models.EmailMagicLink,
+	}
+
+	result, err := client.CreateSelfRegistrationProfile(newProfile)
+	if err != nil {
+		log.Fatalf("Error creating self-registration profile: %v", err)
+	}
+
+	// Extract the ID from the result
+	resultJSON, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		log.Fatalf("Error marshaling result to JSON: %v", err)
+	}
+	fmt.Println("Created self-registration profile:")
+	fmt.Println(string(resultJSON))
+
+	// Parse the result to get the ID
+	resultMap, ok := result.(map[string]interface{})
+	if !ok {
+		log.Fatalf("Error parsing result: unexpected type")
+	}
+
+	profileMap, ok := resultMap["self_registration_profile"].(map[string]interface{})
+	if !ok {
+		log.Fatalf("Error parsing result: self_registration_profile not found or not a map")
+	}
+
+	profileID := int(profileMap["id"].(float64))
+	fmt.Printf("\nCreated profile ID: %d\n", profileID)
+
+	// Get the profile by ID
+	fmt.Printf("\nFetching profile with ID %d...\n", profileID)
+	profile, err := client.GetSelfRegistrationProfile(profileID)
+	if err != nil {
+		log.Fatalf("Error getting self-registration profile: %v", err)
+	}
+
+	// Pretty print the profile
+	profileJSON, err := json.MarshalIndent(profile, "", "  ")
+	if err != nil {
+		log.Fatalf("Error marshaling profile to JSON: %v", err)
+	}
+	fmt.Println("Self-registration profile:")
+	fmt.Println(string(profileJSON))
+
+	// Update the profile
+	fmt.Printf("\nUpdating profile with ID %d...\n", profileID)
+	updatedProfile := models.SelfRegistrationProfile{
+		Name:                 "Updated Test Profile via SDK",
+		URL:                  "test-profile-sdk-" + os.Getenv("USER"),
+		Enabled:              false,
+		Moderated:            true,
+		Helptext:             "Updated welcome message.",
+		ThankyouMessage:      "Updated thank you message!",
+		EmailVerificationType: models.EmailOTP,
+	}
+
+	updateResult, err := client.UpdateSelfRegistrationProfile(profileID, updatedProfile)
+	if err != nil {
+		log.Fatalf("Error updating self-registration profile: %v", err)
+	}
+
+	// Pretty print the update result
+	updateResultJSON, err := json.MarshalIndent(updateResult, "", "  ")
+	if err != nil {
+		log.Fatalf("Error marshaling update result to JSON: %v", err)
+	}
+	fmt.Println("Updated self-registration profile:")
+	fmt.Println(string(updateResultJSON))
+
+	// Delete the profile
+	fmt.Printf("\nDeleting profile with ID %d...\n", profileID)
+	deleteResult, err := client.DeleteSelfRegistrationProfile(profileID)
+	if err != nil {
+		log.Fatalf("Error deleting self-registration profile: %v", err)
+	}
+
+	fmt.Println("Profile deleted successfully!")
+	fmt.Printf("Delete result: %v\n", deleteResult)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/onelogin/onelogin-go-sdk/v4
 
 go 1.18
+
+require github.com/joho/godotenv v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=

--- a/pkg/onelogin/models/self_registration_profile.go
+++ b/pkg/onelogin/models/self_registration_profile.go
@@ -1,0 +1,54 @@
+package models
+
+// SelfRegistrationProfile represents a OneLogin Self-Registration Profile
+type SelfRegistrationProfile struct {
+	ID                   int32                         `json:"id,omitempty"`
+	Name                 string                        `json:"name"`
+	URL                  string                        `json:"url"`
+	Enabled              bool                          `json:"enabled"`
+	Moderated            bool                          `json:"moderated"`
+	DefaultRoleID        int32                         `json:"default_role_id,omitempty"`
+	DefaultGroupID       int32                         `json:"default_group_id,omitempty"`
+	Helptext             string                        `json:"helptext,omitempty"`
+	ThankyouMessage      string                        `json:"thankyou_message,omitempty"`
+	DomainBlacklist      string                        `json:"domain_blacklist,omitempty"`
+	DomainWhitelist      string                        `json:"domain_whitelist,omitempty"`
+	DomainListStrategy   int32                         `json:"domain_list_strategy,omitempty"`
+	EmailVerificationType string                       `json:"email_verification_type,omitempty"`
+	Fields               []SelfRegistrationProfileField `json:"fields,omitempty"`
+}
+
+// SelfRegistrationProfileField represents a field in a Self-Registration Profile
+type SelfRegistrationProfileField struct {
+	ID                      int32  `json:"id,omitempty"`
+	CustomAttributeID       int32  `json:"custom_attribute_id"`
+	Name                    string `json:"name,omitempty"`
+	Position                int32  `json:"position,omitempty"`
+	SelfRegistrationProfileID int32 `json:"self_registration_profile_id,omitempty"`
+}
+
+// SelfRegistrationProfileQuery represents available query parameters for self-registration profiles
+type SelfRegistrationProfileQuery struct {
+	Limit  string `json:"limit,omitempty"`
+	Page   string `json:"page,omitempty"`
+}
+
+// Domain list strategy constants
+const (
+	DomainBlacklistStrategy int32 = 0
+	DomainWhitelistStrategy int32 = 1
+)
+
+// Email verification type constants
+const (
+	EmailMagicLink string = "Email MagicLink"
+	EmailOTP       string = "Email OTP"
+)
+
+// GetKeyValidators returns the validators for the query parameters
+func (q *SelfRegistrationProfileQuery) GetKeyValidators() map[string]func(interface{}) bool {
+	return map[string]func(interface{}) bool{
+		"limit": validateString,
+		"page":  validateString,
+	}
+}

--- a/pkg/onelogin/self_registration_profiles.go
+++ b/pkg/onelogin/self_registration_profiles.go
@@ -1,0 +1,158 @@
+package onelogin
+
+import (
+	"context"
+	
+	mod "github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/models"
+	utl "github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/utilities"
+)
+
+const (
+	SelfRegistrationProfilesPath string = "api/2/self_registration_profiles"
+)
+
+// GetSelfRegistrationProfiles retrieves all self-registration profiles
+func (sdk *OneloginSDK) GetSelfRegistrationProfiles(query mod.Queryable) (interface{}, error) {
+	return sdk.GetSelfRegistrationProfilesWithContext(context.Background(), query)
+}
+
+// GetSelfRegistrationProfilesWithContext retrieves all self-registration profiles using the provided context
+func (sdk *OneloginSDK) GetSelfRegistrationProfilesWithContext(ctx context.Context, query mod.Queryable) (interface{}, error) {
+	p, err := utl.BuildAPIPath(SelfRegistrationProfilesPath)
+	if err != nil {
+		return nil, err
+	}
+	
+	resp, err := sdk.Client.GetWithContext(ctx, &p, query)
+	if err != nil {
+		return nil, err
+	}
+	
+	return utl.CheckHTTPResponse(resp)
+}
+
+// GetSelfRegistrationProfile retrieves a specific self-registration profile by ID
+func (sdk *OneloginSDK) GetSelfRegistrationProfile(id int) (interface{}, error) {
+	return sdk.GetSelfRegistrationProfileWithContext(context.Background(), id)
+}
+
+// GetSelfRegistrationProfileWithContext retrieves a specific self-registration profile by ID using the provided context
+func (sdk *OneloginSDK) GetSelfRegistrationProfileWithContext(ctx context.Context, id int) (interface{}, error) {
+	p, err := utl.BuildAPIPath(SelfRegistrationProfilesPath, id)
+	if err != nil {
+		return nil, err
+	}
+	
+	resp, err := sdk.Client.GetWithContext(ctx, &p, nil)
+	if err != nil {
+		return nil, err
+	}
+	
+	return utl.CheckHTTPResponse(resp)
+}
+
+// CreateSelfRegistrationProfile creates a new self-registration profile
+func (sdk *OneloginSDK) CreateSelfRegistrationProfile(profile mod.SelfRegistrationProfile) (interface{}, error) {
+	return sdk.CreateSelfRegistrationProfileWithContext(context.Background(), profile)
+}
+
+// CreateSelfRegistrationProfileWithContext creates a new self-registration profile using the provided context
+func (sdk *OneloginSDK) CreateSelfRegistrationProfileWithContext(ctx context.Context, profile mod.SelfRegistrationProfile) (interface{}, error) {
+	p, err := utl.BuildAPIPath(SelfRegistrationProfilesPath)
+	if err != nil {
+		return nil, err
+	}
+	
+	resp, err := sdk.Client.PostWithContext(ctx, &p, map[string]mod.SelfRegistrationProfile{
+		"self_registration_profile": profile,
+	})
+	if err != nil {
+		return nil, err
+	}
+	
+	return utl.CheckHTTPResponse(resp)
+}
+
+// UpdateSelfRegistrationProfile updates an existing self-registration profile
+func (sdk *OneloginSDK) UpdateSelfRegistrationProfile(id int, profile mod.SelfRegistrationProfile) (interface{}, error) {
+	return sdk.UpdateSelfRegistrationProfileWithContext(context.Background(), id, profile)
+}
+
+// UpdateSelfRegistrationProfileWithContext updates an existing self-registration profile using the provided context
+func (sdk *OneloginSDK) UpdateSelfRegistrationProfileWithContext(ctx context.Context, id int, profile mod.SelfRegistrationProfile) (interface{}, error) {
+	p, err := utl.BuildAPIPath(SelfRegistrationProfilesPath, id)
+	if err != nil {
+		return nil, err
+	}
+	
+	resp, err := sdk.Client.PutWithContext(ctx, &p, map[string]mod.SelfRegistrationProfile{
+		"self_registration_profile": profile,
+	})
+	if err != nil {
+		return nil, err
+	}
+	
+	return utl.CheckHTTPResponse(resp)
+}
+
+// DeleteSelfRegistrationProfile deletes a self-registration profile
+func (sdk *OneloginSDK) DeleteSelfRegistrationProfile(id int) (interface{}, error) {
+	return sdk.DeleteSelfRegistrationProfileWithContext(context.Background(), id)
+}
+
+// DeleteSelfRegistrationProfileWithContext deletes a self-registration profile using the provided context
+func (sdk *OneloginSDK) DeleteSelfRegistrationProfileWithContext(ctx context.Context, id int) (interface{}, error) {
+	p, err := utl.BuildAPIPath(SelfRegistrationProfilesPath, id)
+	if err != nil {
+		return nil, err
+	}
+	
+	resp, err := sdk.Client.DeleteWithContext(ctx, &p)
+	if err != nil {
+		return nil, err
+	}
+	
+	return utl.CheckHTTPResponse(resp)
+}
+
+// CreateSelfRegistrationProfileField creates a new field for a self-registration profile
+func (sdk *OneloginSDK) CreateSelfRegistrationProfileField(profileID int, customAttributeID int) (interface{}, error) {
+	return sdk.CreateSelfRegistrationProfileFieldWithContext(context.Background(), profileID, customAttributeID)
+}
+
+// CreateSelfRegistrationProfileFieldWithContext creates a new field for a self-registration profile using the provided context
+func (sdk *OneloginSDK) CreateSelfRegistrationProfileFieldWithContext(ctx context.Context, profileID int, customAttributeID int) (interface{}, error) {
+	p, err := utl.BuildAPIPath(SelfRegistrationProfilesPath, profileID, "self_registration_profile_fields")
+	if err != nil {
+		return nil, err
+	}
+	
+	resp, err := sdk.Client.PostWithContext(ctx, &p, map[string]int{
+		"custom_attribute_id": customAttributeID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	
+	return utl.CheckHTTPResponse(resp)
+}
+
+// DeleteSelfRegistrationProfileField deletes a field from a self-registration profile
+func (sdk *OneloginSDK) DeleteSelfRegistrationProfileField(profileID int, fieldID int) (interface{}, error) {
+	return sdk.DeleteSelfRegistrationProfileFieldWithContext(context.Background(), profileID, fieldID)
+}
+
+// DeleteSelfRegistrationProfileFieldWithContext deletes a field from a self-registration profile using the provided context
+func (sdk *OneloginSDK) DeleteSelfRegistrationProfileFieldWithContext(ctx context.Context, profileID int, fieldID int) (interface{}, error) {
+	p, err := utl.BuildAPIPath(SelfRegistrationProfilesPath, profileID, "self_registration_profile_fields", fieldID)
+	if err != nil {
+		return nil, err
+	}
+	
+	resp, err := sdk.Client.DeleteWithContext(ctx, &p)
+	if err != nil {
+		return nil, err
+	}
+	
+	return utl.CheckHTTPResponse(resp)
+}

--- a/pkg/onelogin/utilities/validPaths.go
+++ b/pkg/onelogin/utilities/validPaths.go
@@ -114,4 +114,8 @@ var validPaths = []string{
 	"^/api/2/branding/brands/[0-9]+/templates/[a-zA-Z0-9_-]+/[a-zA-Z]+$",
 	"^/api/2/branding/brands/master/templates/[a-zA-Z0-9_-]+$",
 	"^/api/2/branding/brands/master/templates/[a-zA-Z0-9_-]+/[a-zA-Z]+$",
+	"^/api/2/self_registration_profiles$",
+	"^/api/2/self_registration_profiles/[0-9]+$",
+	"^/api/2/self_registration_profiles/[0-9]+/self_registration_profile_fields$",
+	"^/api/2/self_registration_profiles/[0-9]+/self_registration_profile_fields/[0-9]+$",
 }


### PR DESCRIPTION
# Add Support for Self-Registration Profiles API Endpoints

## Description
This PR adds support for the Self-Registration Profiles API endpoints to the OneLogin Go SDK. These endpoints allow users to manage self-registration profiles programmatically.

## Features Added
- Models for self-registration profiles and fields
- API methods for CRUD operations on self-registration profiles
- API methods for managing profile fields
- Constants for domain list strategies and email verification types
- Test program demonstrating usage

## API Endpoints Supported
- GET /api/2/self_registration_profiles
- GET /api/2/self_registration_profiles/:id
- POST /api/2/self_registration_profiles
- PUT /api/2/self_registration_profiles/:id
- DELETE /api/2/self_registration_profiles/:id
- POST /api/2/self_registration_profiles/:id/self_registration_profile_fields
- DELETE /api/2/self_registration_profiles/:id/self_registration_profile_fields/:field_id

## Testing
A test program is included in cmd/test_self_registration/main.go that demonstrates how to use the new API methods.
