### PR TITLE
feat: add V2 Groups API CRUD methods

### DIFF
--- a/pkg/onelogin/authentication/authenticator.go
+++ b/pkg/onelogin/authentication/authenticator.go
@@ -114,7 +114,7 @@ func (a *Authenticator) RevokeToken(token *string) error {
 	}
 
 	// Convert payload to JSON
-	jsonData, err := json.Marshal(data)
+	jsonData, err := json.Marshal(data) // #nosec G117 -- access_token field name is required by the OAuth2 revocation spec
 	if err != nil {
 		return fmt.Errorf("failed to create revocation request: %w", err)
 	}

--- a/pkg/onelogin/groups.go
+++ b/pkg/onelogin/groups.go
@@ -1,9 +1,15 @@
 package onelogin
 
-import utl "github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/utilities"
+import (
+	"context"
+
+	mod "github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/models"
+	utl "github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/utilities"
+)
 
 const (
-	GroupsPath = "api/1/groups"
+	GroupsPath   = "api/1/groups"
+	GroupsV2Path = "api/2/groups"
 )
 
 func (sdk *OneloginSDK) GetGroups() (interface{}, error) {
@@ -24,6 +30,70 @@ func (sdk *OneloginSDK) GetGroupByID(groupID int) (interface{}, error) {
 		return nil, err
 	}
 	resp, err := sdk.Client.Get(&p, nil)
+	if err != nil {
+		return nil, err
+	}
+	return utl.CheckHTTPResponse(resp)
+}
+
+func (sdk *OneloginSDK) GetGroupByIDV2(groupID int) (interface{}, error) {
+	return sdk.GetGroupByIDV2WithContext(context.Background(), groupID)
+}
+
+func (sdk *OneloginSDK) GetGroupByIDV2WithContext(ctx context.Context, groupID int) (interface{}, error) {
+	p, err := utl.BuildAPIPath(GroupsV2Path, groupID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := sdk.Client.GetWithContext(ctx, &p, nil)
+	if err != nil {
+		return nil, err
+	}
+	return utl.CheckHTTPResponse(resp)
+}
+
+func (sdk *OneloginSDK) CreateGroup(group *mod.Group) (interface{}, error) {
+	return sdk.CreateGroupWithContext(context.Background(), group)
+}
+
+func (sdk *OneloginSDK) CreateGroupWithContext(ctx context.Context, group *mod.Group) (interface{}, error) {
+	p, err := utl.BuildAPIPath(GroupsV2Path)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := sdk.Client.PostWithContext(ctx, &p, group)
+	if err != nil {
+		return nil, err
+	}
+	return utl.CheckHTTPResponse(resp)
+}
+
+func (sdk *OneloginSDK) UpdateGroup(groupID int, group *mod.Group) (interface{}, error) {
+	return sdk.UpdateGroupWithContext(context.Background(), groupID, group)
+}
+
+func (sdk *OneloginSDK) UpdateGroupWithContext(ctx context.Context, groupID int, group *mod.Group) (interface{}, error) {
+	p, err := utl.BuildAPIPath(GroupsV2Path, groupID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := sdk.Client.PutWithContext(ctx, &p, group)
+	if err != nil {
+		return nil, err
+	}
+	return utl.CheckHTTPResponse(resp)
+}
+
+func (sdk *OneloginSDK) DeleteGroup(groupID int) (interface{}, error) {
+	return sdk.DeleteGroupWithContext(context.Background(), groupID)
+}
+
+func (sdk *OneloginSDK) DeleteGroupWithContext(ctx context.Context, groupID int) (interface{}, error) {
+	p, err := utl.BuildAPIPath(GroupsV2Path, groupID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := sdk.Client.DeleteWithContext(ctx, &p)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/onelogin/models/group.go
+++ b/pkg/onelogin/models/group.go
@@ -3,5 +3,5 @@ package models
 type Group struct {
 	ID        int     `json:"id"`
 	Name      string  `json:"name"`
-	Reference *string `json:"reference"`
+	Reference *string `json:"reference,omitempty"`
 }

--- a/pkg/onelogin/roles.go
+++ b/pkg/onelogin/roles.go
@@ -46,6 +46,24 @@ func (sdk *OneloginSDK) GetRolesWithContext(ctx context.Context, queryParams mod
 	return utl.CheckHTTPResponse(resp)
 }
 
+// GetRolesWithPagination retrieves a list of roles with pagination info from response headers
+func (sdk *OneloginSDK) GetRolesWithPagination(queryParams mod.Queryable) (interface{}, *mod.PaginationInfo, error) {
+	return sdk.GetRolesWithPaginationAndContext(context.Background(), queryParams)
+}
+
+// GetRolesWithPaginationAndContext retrieves a list of roles with pagination info using the provided context
+func (sdk *OneloginSDK) GetRolesWithPaginationAndContext(ctx context.Context, queryParams mod.Queryable) (interface{}, *mod.PaginationInfo, error) {
+	p, err := utl.BuildAPIPath(RolePath)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := sdk.Client.GetWithContext(ctx, &p, queryParams)
+	if err != nil {
+		return nil, nil, err
+	}
+	return utl.CheckHTTPResponseWithPagination(resp)
+}
+
 func (sdk *OneloginSDK) GetRoleByID(id int, queryParams mod.Queryable) (interface{}, error) {
 	return sdk.GetRoleByIDWithContext(context.Background(), id, queryParams)
 }

--- a/pkg/onelogin/utilities/validPaths.go
+++ b/pkg/onelogin/utilities/validPaths.go
@@ -15,6 +15,8 @@ var validPaths = []string{
 	"^/api/1/events/types$",
 	"^/api/1/groups$",
 	"^/api/1/groups/[0-9]+$",
+	"^/api/2/groups$",
+	"^/api/2/groups/[0-9]+$",
 	"^/api/1/login/auth$",
 	"^/api/1/login/verify_factor$",
 	"^/api/1/invites/get_invite_link$",

--- a/pkg/onelogin/utilities/web.go
+++ b/pkg/onelogin/utilities/web.go
@@ -6,9 +6,11 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	olerror "github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/error"
+	mod "github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin/models"
 )
 
 // receive http response, check error code status, if good return json of resp.Body
@@ -60,6 +62,32 @@ func CheckHTTPResponse(resp *http.Response) (any, error) {
 
 	//log.Printf("Response body unmarshaled successfully: %v\n", data)
 	return data, nil
+}
+
+// CheckHTTPResponseWithPagination parses the response body and extracts pagination
+// cursor headers (After-Cursor, Before-Cursor) from the V2 API response.
+func CheckHTTPResponseWithPagination(resp *http.Response) (any, *mod.PaginationInfo, error) {
+	data, err := CheckHTTPResponse(resp)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pagination := &mod.PaginationInfo{
+		AfterCursor:  resp.Header.Get("After-Cursor"),
+		BeforeCursor: resp.Header.Get("Before-Cursor"),
+		Cursor:       resp.Header.Get("Cursor"),
+	}
+	if tp := resp.Header.Get("Total-Pages"); tp != "" {
+		pagination.TotalPages, _ = strconv.Atoi(tp)
+	}
+	if cp := resp.Header.Get("Current-Page"); cp != "" {
+		pagination.CurrentPage, _ = strconv.Atoi(cp)
+	}
+	if tc := resp.Header.Get("Total-Count"); tc != "" {
+		pagination.TotalCount, _ = strconv.Atoi(tc)
+	}
+
+	return data, pagination, nil
 }
 
 // CheckHTTPResponseAndUnmarshal checks the HTTP response and unmarshals the response body into the target struct

--- a/pkg/services/olhttp/olrequest.go
+++ b/pkg/services/olhttp/olrequest.go
@@ -243,7 +243,7 @@ func (svc *OLHTTPService) executeHTTP(req *http.Request, resourceRequest mod.OLH
 	}
 	resp, err := svc.Config.Client.Do(req)
 	if err != nil {
-		log.Println("Executing Request To", req.URL, "With", resourceRequest.Payload)
+		log.Println("Executing Request To", req.URL, "With", resourceRequest.Payload) // #nosec G706 -- error context logging, not user-facing
 		log.Println("HTTP Transport Error", err)
 		return nil, nil, customerror.ReqErrorWrapper(resp, svc.ErrorContext, err)
 	}


### PR DESCRIPTION
## Summary

### V2 Groups CRUD (onelogin/terraform-provider-onelogin#204)
- Add `CreateGroup`, `GetGroupByIDV2`, `UpdateGroup`, and `DeleteGroup` methods using the V2 API path (`api/2/groups`)
- Follow the same `WithContext` pattern used by roles
- Add `omitempty` to `Group.Reference` JSON tag so unset reference fields are omitted rather than sent as empty strings
- Register V2 groups paths in `validPaths.go`

### Pagination support with cursor headers (onelogin/terraform-provider-onelogin#203)
- Add `CheckHTTPResponseWithPagination` to `web.go` — extracts `After-Cursor`, `Before-Cursor`, `Total-Pages`, `Current-Page`, and `Total-Count` headers from V2 API responses into the existing `PaginationInfo` model
- Add `GetRolesWithPagination` / `GetRolesWithPaginationAndContext` methods so callers can properly paginate using the opaque cursor values from response headers, instead of fabricating cursors from item IDs (which the API now rejects with 400)

### CI fix
- Add `#nosec` annotations for pre-existing G117 and G706 gosec findings that started failing with newer gosec versions

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Manual verification against OneLogin V2 groups endpoint
- [ ] Manual verification of cursor-based pagination on roles endpoint