### PR TITLE
fix: correct user mapping update payload for disable lifecycle

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,5 +17,7 @@ jobs:
       run: go build ./...
     - name: Vet
       run: go vet ./...
+    - name: Test
+      run: make test
     - name: Secure
       run: make secure

--- a/pkg/onelogin/user_mappings.go
+++ b/pkg/onelogin/user_mappings.go
@@ -63,6 +63,49 @@ func (sdk *OneloginSDK) CreateUserMapping(mapping mod.UserMapping) (*mod.UserMap
 	return &newMapping, err
 }
 
+// buildUserMappingUpdatePayload converts a UserMapping into the body the mappings
+// update endpoint expects. Two rules cannot be expressed by the model's struct
+// tags, so the body is assembled as a map instead of marshaling the struct:
+//
+//   - "id" is never sent. The endpoint takes the mapping ID from the URL and
+//     rejects a body that also carries it.
+//   - "position" must be explicitly null when the mapping is being disabled.
+//     A disabled mapping has no position, and sending its previous position is
+//     rejected. `json:"position,omitempty"` can only omit the key, never emit
+//     an explicit null.
+//
+// These rules are specific to update; create must not force a null position, so
+// this is deliberately not a MarshalJSON method on models.UserMapping.
+//
+// Every other field keeps the omitempty behaviour of models.UserMapping, so a
+// partial update does not blank out fields the caller left unset.
+func buildUserMappingUpdatePayload(mapping mod.UserMapping) map[string]interface{} {
+	// conditions and actions carry no omitempty on the model and are always sent
+	payload := map[string]interface{}{
+		"conditions": mapping.Conditions,
+		"actions":    mapping.Actions,
+	}
+
+	if mapping.Name != nil {
+		payload["name"] = mapping.Name
+	}
+	if mapping.Match != nil {
+		payload["match"] = mapping.Match
+	}
+	if mapping.Enabled != nil {
+		payload["enabled"] = mapping.Enabled
+	}
+
+	switch {
+	case mapping.Enabled != nil && !*mapping.Enabled:
+		payload["position"] = nil
+	case mapping.Position != nil:
+		payload["position"] = mapping.Position
+	}
+
+	return payload
+}
+
 // UpdateUserMapping updates an existing User Mapping
 // Returns the updated UserMapping object or an error
 func (sdk *OneloginSDK) UpdateUserMapping(mappingID int32, mapping mod.UserMapping) (*mod.UserMapping, error) {
@@ -70,7 +113,7 @@ func (sdk *OneloginSDK) UpdateUserMapping(mappingID int32, mapping mod.UserMappi
 	if err != nil {
 		return nil, err
 	}
-	resp, err := sdk.Client.Put(&p, mapping)
+	resp, err := sdk.Client.Put(&p, buildUserMappingUpdatePayload(mapping))
 	if err != nil {
 		return nil, err
 	}

--- a/tests/user_mappings_test.go
+++ b/tests/user_mappings_test.go
@@ -384,7 +384,8 @@ func captureUserMappingUpdateBody(t *testing.T, mapping models.UserMapping) map[
 		}
 
 		// The update flow re-fetches the mapping when the API answers with just an
-		// ID, so the same payload serves both the PUT and the follow-up GET.
+		// ID, so this response body is returned for both the PUT and the
+		// follow-up GET. Only the PUT carries a request body.
 		mockResponse := `{"id": 789, "name": "Test Mapping", "match": "all", "enabled": true}`
 		return &http.Response{
 			StatusCode: 200,

--- a/tests/user_mappings_test.go
+++ b/tests/user_mappings_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"testing"
@@ -356,6 +357,141 @@ func TestUserMappings(t *testing.T) {
 		err := sdk.DeleteUserMapping(123)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
+		}
+	})
+}
+// captureUserMappingUpdateBody drives UpdateUserMapping through the mock transport
+// and returns the decoded JSON body that was actually sent on the PUT request.
+func captureUserMappingUpdateBody(t *testing.T, mapping models.UserMapping) map[string]interface{} {
+	t.Helper()
+
+	client, mockHttpClient := setupMockClient()
+	sdk := &onelogin.OneloginSDK{Client: client}
+
+	var sentBody map[string]interface{}
+	sawPut := false
+
+	mockHttpClient.DoFunc = func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodPut {
+			sawPut = true
+			raw, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("Expected to read the PUT body, got %v", err)
+			}
+			if err := json.Unmarshal(raw, &sentBody); err != nil {
+				t.Fatalf("Expected the PUT body to be valid JSON, got %v (%s)", err, raw)
+			}
+		}
+
+		// The update flow re-fetches the mapping when the API answers with just an
+		// ID, so the same payload serves both the PUT and the follow-up GET.
+		mockResponse := `{"id": 789, "name": "Test Mapping", "match": "all", "enabled": true}`
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewBufferString(mockResponse)),
+		}, nil
+	}
+
+	if _, err := sdk.UpdateUserMapping(789, mapping); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !sawPut {
+		t.Fatal("Expected UpdateUserMapping to send a PUT request")
+	}
+
+	return sentBody
+}
+
+// TestUserMappingUpdatePayload covers the wire format of the mappings update
+// endpoint: the ID belongs in the URL only, and a mapping being disabled must
+// send an explicit null position. Both were causing HTTP 422 responses.
+func TestUserMappingUpdatePayload(t *testing.T) {
+	name := "Test Mapping"
+	match := "all"
+	position := int32(9)
+	enabled := true
+	disabled := false
+	id := int32(789)
+
+	t.Run("omits the id from the body", func(t *testing.T) {
+		body := captureUserMappingUpdateBody(t, models.UserMapping{
+			ID:      &id,
+			Name:    &name,
+			Match:   &match,
+			Enabled: &enabled,
+		})
+
+		if _, present := body["id"]; present {
+			t.Fatalf("Expected no id in the update body, got %v", body["id"])
+		}
+	})
+
+	t.Run("sends a null position when disabling", func(t *testing.T) {
+		body := captureUserMappingUpdateBody(t, models.UserMapping{
+			ID:       &id,
+			Name:     &name,
+			Match:    &match,
+			Enabled:  &disabled,
+			Position: &position,
+		})
+
+		value, present := body["position"]
+		if !present {
+			t.Fatal("Expected an explicit position key when disabling, got none")
+		}
+		if value != nil {
+			t.Fatalf("Expected position to be null when disabling, got %v", value)
+		}
+	})
+
+	t.Run("keeps an explicit position when enabled", func(t *testing.T) {
+		body := captureUserMappingUpdateBody(t, models.UserMapping{
+			Name:     &name,
+			Match:    &match,
+			Enabled:  &enabled,
+			Position: &position,
+		})
+
+		if body["position"] != float64(position) {
+			t.Fatalf("Expected position to be %d, got %v", position, body["position"])
+		}
+	})
+
+	t.Run("omits the position when it is unset and enabled", func(t *testing.T) {
+		body := captureUserMappingUpdateBody(t, models.UserMapping{
+			Name:    &name,
+			Match:   &match,
+			Enabled: &enabled,
+		})
+
+		if value, present := body["position"]; present {
+			t.Fatalf("Expected no position in the update body, got %v", value)
+		}
+	})
+
+	t.Run("does not send unset fields as null", func(t *testing.T) {
+		body := captureUserMappingUpdateBody(t, models.UserMapping{
+			Enabled: &enabled,
+		})
+
+		for _, field := range []string{"name", "match"} {
+			if value, present := body[field]; present {
+				t.Fatalf("Expected %q to be omitted when unset, got %v", field, value)
+			}
+		}
+	})
+
+	t.Run("always sends conditions and actions", func(t *testing.T) {
+		body := captureUserMappingUpdateBody(t, models.UserMapping{
+			Name:    &name,
+			Match:   &match,
+			Enabled: &enabled,
+		})
+
+		for _, field := range []string{"conditions", "actions"} {
+			if _, present := body[field]; !present {
+				t.Fatalf("Expected %q to always be present in the update body", field)
+			}
 		}
 	})
 }


### PR DESCRIPTION
## Problem

The `api/2/mappings` update endpoint returns **HTTP 422** in two situations, both caused by the body this SDK sends:

1. The body carries `id`. The endpoint takes the mapping ID from the URL and rejects a body that also contains it.
2. A mapping being disabled still carries its previous `position`. A disabled mapping has no position, and the endpoint rejects the stale value.

`UpdateUserMapping` marshaled `models.UserMapping` directly, so it always sent `id`, and `json:"position,omitempty"` could only ever *omit* the position key — never emit the explicit `null` the endpoint requires.

Reported downstream in [terraform-provider-onelogin#220](https://github.com/onelogin/terraform-provider-onelogin/issues/220), where `enabled = true` → `false` fails on apply.

## Fix

`UpdateUserMapping` now builds its request body via `buildUserMappingUpdatePayload`, which:

- never sends `id`
- sends `position: null` when `Enabled` is explicitly `false`
- sends `position` only when the caller set it, otherwise omits it
- **preserves the `omitempty` behaviour of every other field**, so a partial update does not blank out values the caller left unset

That last point is why the payload is assembled field-by-field rather than dumped from a map of all fields — marshaling a map emits every key, which would turn `UpdateUserMapping(id, models.UserMapping{Enabled: &f})` into `{"name": null, "match": null, ...}`.

This follows the same shape as the earlier Role empty-array fix (#106). It is deliberately *not* a `MarshalJSON` method on `models.UserMapping`: the rules are update-specific, and forcing a null position on create would be wrong.

## Testing

Added `TestUserMappingUpdatePayload` to `tests/user_mappings_test.go`. It drives the exported `UpdateUserMapping` through the existing mock transport and asserts on the **actual serialized PUT body**, so it stays valid regardless of how the payload is built internally.

Cases covered: no `id`; null `position` when disabling; explicit `position` preserved when enabled; `position` omitted when unset; unset optional fields not sent as `null`; `conditions`/`actions` always present.

Verified the two subtests matching the reported causes fail without the fix:

```
--- FAIL: TestUserMappingUpdatePayload/omits_the_id_from_the_body
        Expected no id in the update body, got 789
--- FAIL: TestUserMappingUpdatePayload/sends_a_null_position_when_disabling
        Expected position to be null when disabling, got 9
```

`go build ./...`, `go vet ./...` and `make test` all pass. No new `gofmt` findings (the pre-existing list is unchanged).

## CI

CI ran `fmt`, `build`, `vet` and `secure` but **never ran the test suite**, despite the `test` target existing in the `Makefile`. Added a `make test` step so this regression — and the rest of `tests/` — is actually enforced.

## Downstream

[terraform-provider-onelogin#221](https://github.com/onelogin/terraform-provider-onelogin/pull/221) currently patches this same logic directly inside its `vendor/` directory, which would be silently reverted by the next `go mod vendor`. Once this is released, that PR should drop the vendored edit and bump the SDK instead.
