### PR TITLE
chore: bump version to 4.9.0

### DIFF
--- a/pkg/onelogin/version.go
+++ b/pkg/onelogin/version.go
@@ -1,3 +1,3 @@
 package onelogin
 
-const Version = "4.7.0"
+const Version = "4.9.0"


### PR DESCRIPTION
Prepares the `v4.9.0` release.

`pkg/onelogin/version.go` still read `4.7.0` — it was never bumped when `v4.8.0` was tagged, so the constant and the git tag had drifted two releases apart.

Minor rather than patch because `main` carries an unreleased feature on top of `v4.8.0`, not just a fix:

- #110 — V2 Groups CRUD + cursor pagination (feature)
- #112 — user mapping update payload fix, unblocks [terraform-provider-onelogin#220](https://github.com/onelogin/terraform-provider-onelogin/issues/220)

Releases are cut by goreleaser on tag push; the tag follows once this merges.