### PR TITLE
feat: add paginated context-aware role sub-endpoint getters

### DIFF
--- a/pkg/onelogin/roles.go
+++ b/pkg/onelogin/roles.go
@@ -128,6 +128,26 @@ func (sdk *OneloginSDK) GetRoleUsers(roleID int, queryParams mod.Queryable) (int
 	return utl.CheckHTTPResponse(resp)
 }
 
+// GetRoleUsersWithPagination retrieves a role's users with pagination info from response headers
+func (sdk *OneloginSDK) GetRoleUsersWithPagination(roleID int, queryParams mod.Queryable) (interface{}, *mod.PaginationInfo, error) {
+	return sdk.GetRoleUsersWithPaginationAndContext(context.Background(), roleID, queryParams)
+}
+
+// GetRoleUsersWithPaginationAndContext retrieves a role's users with pagination info using the provided context.
+// This endpoint is paginated: callers should follow PaginationInfo.AfterCursor until it is empty to
+// retrieve every user, otherwise only the first page is returned.
+func (sdk *OneloginSDK) GetRoleUsersWithPaginationAndContext(ctx context.Context, roleID int, queryParams mod.Queryable) (interface{}, *mod.PaginationInfo, error) {
+	p, err := utl.BuildAPIPath(RolePath, roleID, "users")
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := sdk.Client.GetWithContext(ctx, &p, queryParams)
+	if err != nil {
+		return nil, nil, err
+	}
+	return utl.CheckHTTPResponseWithPagination(resp)
+}
+
 func (sdk *OneloginSDK) AddRoleUsers(roleID int, users []int) (interface{}, error) {
 	p, err := utl.BuildAPIPath(RolePath, roleID, "users")
 	if err != nil {
@@ -165,6 +185,26 @@ func (sdk *OneloginSDK) GetRoleAdmins(roleID int) (interface{}, error) {
 	return utl.CheckHTTPResponse(resp)
 }
 
+// GetRoleAdminsWithPagination retrieves a role's admins with pagination info from response headers
+func (sdk *OneloginSDK) GetRoleAdminsWithPagination(roleID int, queryParams mod.Queryable) (interface{}, *mod.PaginationInfo, error) {
+	return sdk.GetRoleAdminsWithPaginationAndContext(context.Background(), roleID, queryParams)
+}
+
+// GetRoleAdminsWithPaginationAndContext retrieves a role's admins with pagination info using the provided context.
+// This endpoint is paginated: callers should follow PaginationInfo.AfterCursor until it is empty to
+// retrieve every admin, otherwise only the first page is returned.
+func (sdk *OneloginSDK) GetRoleAdminsWithPaginationAndContext(ctx context.Context, roleID int, queryParams mod.Queryable) (interface{}, *mod.PaginationInfo, error) {
+	p, err := utl.BuildAPIPath(RolePath, roleID, "admins")
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := sdk.Client.GetWithContext(ctx, &p, queryParams)
+	if err != nil {
+		return nil, nil, err
+	}
+	return utl.CheckHTTPResponseWithPagination(resp)
+}
+
 func (sdk *OneloginSDK) AddRoleAdmins(roleID int, admins []int) (interface{}, error) {
 	p, err := utl.BuildAPIPath(RolePath, roleID, "admins")
 	if err != nil {
@@ -200,6 +240,26 @@ func (sdk *OneloginSDK) GetRoleApps(roleID int) (interface{}, error) {
 		return nil, err
 	}
 	return utl.CheckHTTPResponse(resp)
+}
+
+// GetRoleAppsWithPagination retrieves a role's apps with pagination info from response headers
+func (sdk *OneloginSDK) GetRoleAppsWithPagination(roleID int, queryParams mod.Queryable) (interface{}, *mod.PaginationInfo, error) {
+	return sdk.GetRoleAppsWithPaginationAndContext(context.Background(), roleID, queryParams)
+}
+
+// GetRoleAppsWithPaginationAndContext retrieves a role's apps with pagination info using the provided context.
+// This endpoint is paginated: callers should follow PaginationInfo.AfterCursor until it is empty to
+// retrieve every app, otherwise only the first page is returned.
+func (sdk *OneloginSDK) GetRoleAppsWithPaginationAndContext(ctx context.Context, roleID int, queryParams mod.Queryable) (interface{}, *mod.PaginationInfo, error) {
+	p, err := utl.BuildAPIPath(RolePath, roleID, "apps")
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := sdk.Client.GetWithContext(ctx, &p, queryParams)
+	if err != nil {
+		return nil, nil, err
+	}
+	return utl.CheckHTTPResponseWithPagination(resp)
 }
 
 // was setRoleApps

--- a/pkg/onelogin/version.go
+++ b/pkg/onelogin/version.go
@@ -1,3 +1,3 @@
 package onelogin
 
-const Version = "4.9.0"
+const Version = "4.10.0"

--- a/tests/role_members_test.go
+++ b/tests/role_members_test.go
@@ -1,0 +1,212 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/onelogin/onelogin-go-sdk/v4/pkg/onelogin"
+)
+
+// roleMemberQuery is a minimal Queryable for exercising the paginated role
+// sub-endpoint getters. The V2 API treats cursor and limit/page as mutually
+// exclusive, so callers clear limit/page once a cursor is in hand.
+type roleMemberQuery struct {
+	Limit  string `json:"limit,omitempty"`
+	Page   string `json:"page,omitempty"`
+	Cursor string `json:"cursor,omitempty"`
+}
+
+func (q *roleMemberQuery) GetKeyValidators() map[string]func(interface{}) bool {
+	isString := func(v interface{}) bool {
+		_, ok := v.(string)
+		return ok
+	}
+	return map[string]func(interface{}) bool{
+		"limit":  isString,
+		"page":   isString,
+		"cursor": isString,
+	}
+}
+
+// respondWith builds a 200 response carrying body and the supplied After-Cursor.
+func respondWith(body string, afterCursor string) *http.Response {
+	header := make(http.Header)
+	if afterCursor != "" {
+		header.Set("After-Cursor", afterCursor)
+	}
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+		Header:     header,
+	}
+}
+
+// TestRoleMemberGettersSurfacePagination covers the three role sub-endpoints
+// (apps, users, admins), which are paginated by the V2 API. Each getter must
+// pass query parameters through to the request and surface the After-Cursor
+// response header so callers can walk every page.
+func TestRoleMemberGettersSurfacePagination(t *testing.T) {
+	t.Run("apps getter passes query params and returns After-Cursor", func(t *testing.T) {
+		client := createMockClient()
+		sdk := &onelogin.OneloginSDK{Client: client}
+
+		var gotPath, gotQuery string
+		client.HttpClient.(*MockHttpClient).DoFunc = func(req *http.Request) (*http.Response, error) {
+			gotPath = req.URL.Path
+			gotQuery = req.URL.RawQuery
+			return respondWith(`[{"id":1,"name":"app-one"}]`, "cursor-page-2"), nil
+		}
+
+		result, pagination, err := sdk.GetRoleAppsWithPaginationAndContext(
+			context.Background(), 42, &roleMemberQuery{Limit: "100"})
+		if err != nil {
+			t.Fatalf("GetRoleAppsWithPaginationAndContext failed: %v", err)
+		}
+		if gotPath != "/api/2/roles/42/apps" {
+			t.Errorf("expected path /api/2/roles/42/apps, got %s", gotPath)
+		}
+		if gotQuery != "limit=100" {
+			t.Errorf("expected query limit=100, got %q", gotQuery)
+		}
+		if pagination == nil || pagination.AfterCursor != "cursor-page-2" {
+			t.Fatalf("expected After-Cursor to be surfaced, got %+v", pagination)
+		}
+		items, ok := result.([]interface{})
+		if !ok || len(items) != 1 {
+			t.Fatalf("expected one app in result, got %#v", result)
+		}
+	})
+
+	t.Run("users getter passes query params and returns After-Cursor", func(t *testing.T) {
+		client := createMockClient()
+		sdk := &onelogin.OneloginSDK{Client: client}
+
+		var gotPath, gotQuery string
+		client.HttpClient.(*MockHttpClient).DoFunc = func(req *http.Request) (*http.Response, error) {
+			gotPath = req.URL.Path
+			gotQuery = req.URL.RawQuery
+			return respondWith(`[{"id":10,"username":"joe.user"}]`, "cursor-page-2"), nil
+		}
+
+		_, pagination, err := sdk.GetRoleUsersWithPaginationAndContext(
+			context.Background(), 42, &roleMemberQuery{Cursor: "cursor-page-1"})
+		if err != nil {
+			t.Fatalf("GetRoleUsersWithPaginationAndContext failed: %v", err)
+		}
+		if gotPath != "/api/2/roles/42/users" {
+			t.Errorf("expected path /api/2/roles/42/users, got %s", gotPath)
+		}
+		if gotQuery != "cursor=cursor-page-1" {
+			t.Errorf("expected query cursor=cursor-page-1, got %q", gotQuery)
+		}
+		if pagination == nil || pagination.AfterCursor != "cursor-page-2" {
+			t.Fatalf("expected After-Cursor to be surfaced, got %+v", pagination)
+		}
+	})
+
+	t.Run("admins getter passes query params and returns After-Cursor", func(t *testing.T) {
+		client := createMockClient()
+		sdk := &onelogin.OneloginSDK{Client: client}
+
+		var gotPath string
+		client.HttpClient.(*MockHttpClient).DoFunc = func(req *http.Request) (*http.Response, error) {
+			gotPath = req.URL.Path
+			return respondWith(`[{"id":7,"username":"admin.user"}]`, ""), nil
+		}
+
+		_, pagination, err := sdk.GetRoleAdminsWithPaginationAndContext(
+			context.Background(), 42, nil)
+		if err != nil {
+			t.Fatalf("GetRoleAdminsWithPaginationAndContext failed: %v", err)
+		}
+		if gotPath != "/api/2/roles/42/admins" {
+			t.Errorf("expected path /api/2/roles/42/admins, got %s", gotPath)
+		}
+		// An absent After-Cursor is how the API signals the last page.
+		if pagination == nil || pagination.AfterCursor != "" {
+			t.Fatalf("expected empty After-Cursor on last page, got %+v", pagination)
+		}
+	})
+}
+
+// TestRoleMemberGettersPropagateContext verifies the context reaches the
+// outbound request, so a cancelled Terraform plan stops issuing calls.
+func TestRoleMemberGettersPropagateContext(t *testing.T) {
+	client := createMockClient()
+	sdk := &onelogin.OneloginSDK{Client: client}
+
+	type ctxKey string
+	const key ctxKey = "trace"
+
+	var sawValue interface{}
+	client.HttpClient.(*MockHttpClient).DoFunc = func(req *http.Request) (*http.Response, error) {
+		sawValue = req.Context().Value(key)
+		return respondWith(`[]`, ""), nil
+	}
+
+	ctx := context.WithValue(context.Background(), key, "present")
+	if _, _, err := sdk.GetRoleUsersWithPaginationAndContext(ctx, 42, nil); err != nil {
+		t.Fatalf("GetRoleUsersWithPaginationAndContext failed: %v", err)
+	}
+	if sawValue != "present" {
+		t.Errorf("expected context to reach the request, got %v", sawValue)
+	}
+}
+
+// TestRoleMemberGettersWalkAllPages exercises the cursor loop callers are
+// expected to run: follow After-Cursor until it comes back empty.
+func TestRoleMemberGettersWalkAllPages(t *testing.T) {
+	client := createMockClient()
+	sdk := &onelogin.OneloginSDK{Client: client}
+
+	pages := []struct {
+		body        string
+		afterCursor string
+	}{
+		{`[{"id":1},{"id":2}]`, "cursor-2"},
+		{`[{"id":3}]`, ""},
+	}
+	callCount := 0
+	client.HttpClient.(*MockHttpClient).DoFunc = func(req *http.Request) (*http.Response, error) {
+		page := pages[callCount]
+		callCount++
+		return respondWith(page.body, page.afterCursor), nil
+	}
+
+	var ids []int
+	query := &roleMemberQuery{Limit: "100"}
+	for {
+		result, pagination, err := sdk.GetRoleUsersWithPaginationAndContext(
+			context.Background(), 42, query)
+		if err != nil {
+			t.Fatalf("page %d failed: %v", callCount, err)
+		}
+		items, ok := result.([]interface{})
+		if !ok {
+			t.Fatalf("expected an array, got %#v", result)
+		}
+		for _, item := range items {
+			if obj, ok := item.(map[string]interface{}); ok {
+				if id, ok := obj["id"].(float64); ok {
+					ids = append(ids, int(id))
+				}
+			}
+		}
+		if pagination == nil || pagination.AfterCursor == "" {
+			break
+		}
+		// cursor and limit/page are mutually exclusive in the V2 API
+		query.Cursor = pagination.AfterCursor
+		query.Limit, query.Page = "", ""
+	}
+
+	if callCount != 2 {
+		t.Errorf("expected 2 requests, got %d", callCount)
+	}
+	if len(ids) != 3 || ids[0] != 1 || ids[2] != 3 {
+		t.Errorf("expected ids [1 2 3] across both pages, got %v", ids)
+	}
+}

--- a/tests/role_members_test.go
+++ b/tests/role_members_test.go
@@ -169,8 +169,12 @@ func TestRoleMemberGettersWalkAllPages(t *testing.T) {
 		{`[{"id":1},{"id":2}]`, "cursor-2"},
 		{`[{"id":3}]`, ""},
 	}
+	// Record each request's query string so the walk is verified end to end:
+	// the cursor must actually reach the wire, not just the caller's struct.
+	var sentQueries []string
 	callCount := 0
 	client.HttpClient.(*MockHttpClient).DoFunc = func(req *http.Request) (*http.Response, error) {
+		sentQueries = append(sentQueries, req.URL.RawQuery)
 		page := pages[callCount]
 		callCount++
 		return respondWith(page.body, page.afterCursor), nil
@@ -204,9 +208,18 @@ func TestRoleMemberGettersWalkAllPages(t *testing.T) {
 	}
 
 	if callCount != 2 {
-		t.Errorf("expected 2 requests, got %d", callCount)
+		t.Fatalf("expected 2 requests, got %d", callCount)
 	}
 	if len(ids) != 3 || ids[0] != 1 || ids[2] != 3 {
 		t.Errorf("expected ids [1 2 3] across both pages, got %v", ids)
+	}
+
+	// Page 1 requests a limit; page 2 must carry the cursor instead — with limit
+	// and page cleared, since the V2 API rejects cursor alongside either.
+	if sentQueries[0] != "limit=100" {
+		t.Errorf("first request: expected limit=100, got %q", sentQueries[0])
+	}
+	if sentQueries[1] != "cursor=cursor-2" {
+		t.Errorf("second request: expected cursor=cursor-2 with limit/page cleared, got %q", sentQueries[1])
 	}
 }


### PR DESCRIPTION
## Problem

The three role sub-endpoints — `GET /api/2/roles/{id}/apps`, `/users`, `/admins` — are all documented as paginated ("Pagination is supported on this endpoint"), but the SDK getters can't paginate them:

- `GetRoleApps(roleID int)` and `GetRoleAdmins(roleID int)` take **no query-params argument at all** — both hardcode `sdk.Client.Get(&p, nil)`, so `limit` and `cursor` can't be passed.
- All three use `CheckHTTPResponse` rather than `CheckHTTPResponseWithPagination`, so the `After-Cursor` response header is discarded before the caller sees it.
- All three call `sdk.Client.Get(...)`, which is `GetWithContext(context.Background(), ...)`, so a caller's context — and therefore cancellation — never reaches the request.

The practical effect is that a consumer can only ever read the first page of a role's membership, with no way to detect that more pages exist.

## Changes

Adds `WithPagination` / `WithPaginationAndContext` variants for all three sub-endpoints, mirroring the existing `GetRolesWithPaginationAndContext`:

```go
func (sdk *OneloginSDK) GetRoleAppsWithPaginationAndContext(ctx context.Context, roleID int, queryParams mod.Queryable) (interface{}, *mod.PaginationInfo, error)
func (sdk *OneloginSDK) GetRoleUsersWithPaginationAndContext(ctx context.Context, roleID int, queryParams mod.Queryable) (interface{}, *mod.PaginationInfo, error)
func (sdk *OneloginSDK) GetRoleAdminsWithPaginationAndContext(ctx context.Context, roleID int, queryParams mod.Queryable) (interface{}, *mod.PaginationInfo, error)
```

Each accepts a `Queryable`, uses `GetWithContext`, and returns `PaginationInfo` via the shared `CheckHTTPResponseWithPagination` helper — so header parsing isn't duplicated the way it is in `GetAppUsersWithPaginationAndContext`.

I followed the `(interface{}, *mod.PaginationInfo, error)` shape used by `GetRolesWithPaginationAndContext` rather than the `*mod.PagedResponse` shape used by `GetAppUsersWithPaginationAndContext`. Both patterns exist in the SDK today; the former is the convention within `roles.go`, reuses the shared helper, and matches what the provider already consumes. Happy to switch if you'd rather converge on `PagedResponse`.

**Existing methods are untouched**, so this is purely additive — `version.go` bumped to **4.10.0** (included here per request).

## Tests

New `tests/role_members_test.go`, following the `app_users_test.go` mock-client pattern:

- each getter hits the right path and passes query params through to the request URL
- `After-Cursor` is surfaced from the response header, and an absent header (last page) reads as empty
- context reaches the outbound request
- a full two-page cursor walk accumulates IDs across both pages and stops when the cursor empties, including the `cursor` xor `limit`/`page` handling the V2 API requires

`go build ./...`, `go vet`, and `go test ./...` all pass.

## Why now

Consumed by [terraform-provider-onelogin#223](https://github.com/onelogin/terraform-provider-onelogin/pull/223). That PR replaces a per-resource full-list pagination loop in `roleRead` with direct fetches, which is the right fix for the 500-request refresh storm in [terraform-provider-onelogin#219](https://github.com/onelogin/terraform-provider-onelogin/issues/219) — but it currently reads only the first page of each membership list, so a role with more members than the default page size would write a truncated list into Terraform state and produce a permanent diff. It can't be fixed provider-side without these methods.
